### PR TITLE
Remove references to socket.AddressFamily

### DIFF
--- a/LTTngAnalyzes/common.py
+++ b/LTTngAnalyzes/common.py
@@ -4,7 +4,7 @@ import os
 import socket
 import struct
 from enum import IntEnum
-from socket import AddressFamily
+from socket import socket
 
 NSEC_PER_SEC = 1000000000
 MSEC_PER_NSEC = 1000000
@@ -97,7 +97,7 @@ class FD():
         self.net_read = 0
         self.net_write = 0
         # address family
-        self.family = AddressFamily.AF_UNSPEC
+        self.family = socket.AF_UNSPEC
         # disk read/write (might be cached)
         self.disk_read = 0
         self.disk_write = 0

--- a/LTTngAnalyzes/syscalls.py
+++ b/LTTngAnalyzes/syscalls.py
@@ -1,5 +1,6 @@
 from LTTngAnalyzes.common import *
 from enum import IntEnum
+import socket
 
 #Using IntEnum rather than Enum allows direct serialization
 class IOCategory(IntEnum):
@@ -16,8 +17,8 @@ class IOCategory(IntEnum):
 
 class Syscalls():
     # TODO: decouple socket/family logic from this class
-    INET_FAMILIES = [AddressFamily.AF_INET, AddressFamily.AF_INET6]
-    DISK_FAMILIES = [AddressFamily.AF_UNIX]
+    INET_FAMILIES = [socket.AF_INET, socket.AF_INET6]
+    DISK_FAMILIES = [socket.AF_UNIX]
     # list nof syscalls that open a FD on disk (in the exit_syscall event)
     DISK_OPEN_SYSCALLS = ["sys_open", "sys_openat"]
     # list of syscalls that open a FD on the network (in the exit_syscall event)
@@ -111,7 +112,7 @@ class Syscalls():
             if event["flags"] & O_CLOEXEC == O_CLOEXEC:
                 current_syscall["cloexec"] = 1
         elif name in ["sys_accept"] and "family" in event.keys():
-            if event["family"] == AddressFamily.AF_INET:
+            if event["family"] == socket.AF_INET:
                 ipport = "%s:%d" % (int_to_ipv4(event["v4addr"]), event["sport"])
                 current_syscall["filename"] = ipport
             else:
@@ -143,7 +144,7 @@ class Syscalls():
             family = event["family"]
             current_syscall["family"] = family
         else:
-            family = AddressFamily.AF_UNSPEC
+            family = socket.AF_UNSPEC
             current_syscall["family"] = family
 
         current_syscall["name"] = name
@@ -203,7 +204,7 @@ class Syscalls():
         # when a connect occurs, no new FD is returned, but we can fix
         # the "filename" if we have the destination info
         elif name in ["sys_connect"] and "family" in event.keys():
-            if event["family"] == AddressFamily.AF_INET:
+            if event["family"] == socket.AF_INET:
                 fd = self.get_fd(t, event["fd"])
                 ipport = "%s:%d" % (int_to_ipv4(event["v4addr"]), event["dport"])
                 fd.filename = ipport

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ a list of processes (see `--name` parameter).
 ## Requirements
 * LTTng 2.5
 * Babeltrace 1.2 (with python bindings compiled)
-* Python 3
+* Python 3.3+
 
 ## Install on Ubuntu (12.04 and 14.04 at least)
 ```

--- a/nettop.py
+++ b/nettop.py
@@ -15,6 +15,7 @@
 
 import sys
 import argparse
+import socket
 from babeltrace import *
 from progressbar import *
 from LTTngAnalyzes.common import *
@@ -101,10 +102,10 @@ class NetTop():
 
             for fd in self.tids[tid].fds.values():
                 if fd.fdtype is FDType.net:
-                    if fd.family == AddressFamily.AF_INET:
+                    if fd.family == socket.AF_INET:
                         transferred[tid]['ipv4']['up'] += fd.net_write
                         transferred[tid]['ipv4']['down'] += fd.net_read
-                    elif fd.family == AddressFamily.AF_INET6:
+                    elif fd.family == socket.AF_INET6:
                         transferred[tid]['ipv6']['up'] += fd.net_write
                         transferred[tid]['ipv6']['down'] += fd.net_read
 


### PR DESCRIPTION
Removed references to socket.AddressFamily and IntEnum which were
introduced as of Python 3.4.

Signed-off-by: Jérémie Galarneau jeremie.galarneau@efficios.com
