### PR TITLE
Make user interaction with install.sh more convenient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ proc.db
 .\#*
 tags
 *.swp
+build/
+dist/
+*.egg-info/

--- a/install.sh
+++ b/install.sh
@@ -14,8 +14,10 @@ cd lttnganalysescli
 ./setup.py install
 cd ..
 
-echo "Install lttng-analyses-record in /usr/local/bin/ ? [Yn]"
-read a
+echo
+echo -n "Install lttng-analyses-record in /usr/local/bin/ ? [Y/n] "
+read -n 1 a
+echo
 if test "$a" = 'y' -o "$a" = 'Y' -o "$a" = ''; then
 	install lttng-analyses-record /usr/local/bin/lttng-analyses-record
 fi


### PR DESCRIPTION
A newline before prompting the user makes the prompt easier to see, also echo -n leaves the cursor on the prompt's line, and read -n 1 makes it so the user does not have to type enter after giving their answer.

The changes to gitignore exclude build/install artifacts from the repo.