### PR TITLE
Track chronological fd metadata

### DIFF
--- a/linuxautomaton/linuxautomaton/statedump.py
+++ b/linuxautomaton/linuxautomaton/statedump.py
@@ -23,7 +23,6 @@
 # SOFTWARE.
 
 from linuxautomaton import sp, sv, common
-from collections import OrderedDict
 
 
 class StatedumpStateProvider(sp.StateProvider):
@@ -133,17 +132,13 @@ class StatedumpStateProvider(sp.StateProvider):
             # FIXME: we don't have the info, just assume for now
             newfile.cloexec = 1
             p.fds[fd] = newfile
-            p.chrono_fds[fd] = OrderedDict()
-            p.chrono_fds[fd][event.timestamp] = {
-                "filename": newfile.filename,
-                "fdtype": newfile.fdtype
-            }
+            fdtype = newfile.fdtype
         else:
             # just fix the filename
             p.fds[fd].filename = filename
-            chrono_fd = p.chrono_fds[fd]
-            last_ts = next(reversed(chrono_fd))
-            chrono_fd[last_ts]["filename"] = filename
+            fdtype = p.fds[fd].fdtype
+
+        p.track_chrono_fd(fd, filename, fdtype, event.timestamp)
 
     def _process_lttng_statedump_block_device(self, event):
         d = common.get_disk(event["dev"], self.disks)

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -38,6 +38,9 @@ class Process():
         self.fds = {}
         # indexed by filename
         self.closed_fds = {}
+        # filenames (indexed by timestamp) associated with given fd (top-level
+        # index) at a given point in time
+        self.chrono_fds = {}
         self.current_syscall = {}
         self.init_counts()
 

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -23,6 +23,7 @@
 # SOFTWARE.
 
 import socket
+from collections import OrderedDict
 
 
 class StateVariable:
@@ -76,6 +77,20 @@ class Process():
         # array of IORequest objects for freq analysis later (block and
         # syscalls with no FD like sys_sync)
         self.iorequests = []
+
+    def track_chrono_fd(self, fd, filename, fdtype, timestamp):
+        chrono_metadata = {}
+        chrono_metadata["filename"] = filename
+        chrono_metadata["fdtype"] = fdtype
+
+        if fd not in self.chrono_fds:
+            self.chrono_fds[fd] = OrderedDict()
+            self.chrono_fds[fd][timestamp] = chrono_metadata
+        else:
+            chrono_fd = self.chrono_fds[fd]
+            last_ts = next(reversed(chrono_fd))
+            if filename != chrono_fd[last_ts]["filename"]:
+                chrono_fd[timestamp] = chrono_metadata
 
 
 class CPU():

--- a/linuxautomaton/linuxautomaton/syscalls.py
+++ b/linuxautomaton/linuxautomaton/syscalls.py
@@ -280,7 +280,7 @@ class SyscallsStateProvider(sp.StateProvider):
             chrono_metadata["filename"] = f.filename
             chrono_metadata["fdtype"] = f.fdtype
             proc.chrono_fds[fd] = OrderedDict()
-            proc.chrono_fds[fd][event["timestamp_begin"]] = chrono_metadata
+            proc.chrono_fds[fd][event.timestamp] = chrono_metadata
         else:
             f = proc.fds[fd]
         return f
@@ -392,12 +392,12 @@ class SyscallsStateProvider(sp.StateProvider):
 
         if fd.fd not in t.chrono_fds:
             t.chrono_fds[fd.fd] = OrderedDict()
-            t.chrono_fds[fd.fd][event["timestamp_begin"]] = chrono_metadata
+            t.chrono_fds[fd.fd][event.timestamp] = chrono_metadata
         else:
             chrono_fd = t.chrono_fds[fd.fd]
             last_ts = next(reversed(chrono_fd))
             if fd.filename != chrono_fd[last_ts]["filename"]:
-                chrono_fd[event["timestamp_begin"]] = chrono_metadata
+                chrono_fd[event.timestamp] = chrono_metadata
 
     def read_append(self, fd, proc, count, rq):
         rq.operation = sv.IORequest.OP_READ


### PR DESCRIPTION
This commit introduces a chrono_fds object as an attribute of Process
objects. In it, we track when the file (identified by its name)
associated to a given file descriptor has changed. The object
chrono_fds is indexed by file descriptor (number), and each value is
an OrderedDict which stores all the filenames and filetypes associated
with this fd, indexed by timestamp in nanoseconds.

Limitations: if a program opens a file, closes it, and reopens it with
the same file descriptor, without reusing the FD for any other file in
between, the change will not be tracked in chrono_fds.