### PR TITLE
Fix: correct typo in author email address

### DIFF
--- a/linuxautomaton/linuxautomaton/__init__.py
+++ b/linuxautomaton/linuxautomaton/__init__.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/linuxautomaton/linuxautomaton/automaton.py
+++ b/linuxautomaton/linuxautomaton/automaton.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/linuxautomaton/linuxautomaton/block.py
+++ b/linuxautomaton/linuxautomaton/block.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/linuxautomaton/linuxautomaton/common.py
+++ b/linuxautomaton/linuxautomaton/common.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/linuxautomaton/linuxautomaton/irq.py
+++ b/linuxautomaton/linuxautomaton/irq.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/linuxautomaton/linuxautomaton/mem.py
+++ b/linuxautomaton/linuxautomaton/mem.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/linuxautomaton/linuxautomaton/net.py
+++ b/linuxautomaton/linuxautomaton/net.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/linuxautomaton/linuxautomaton/sched.py
+++ b/linuxautomaton/linuxautomaton/sched.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/linuxautomaton/linuxautomaton/sp.py
+++ b/linuxautomaton/linuxautomaton/sp.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/linuxautomaton/linuxautomaton/statedump.py
+++ b/linuxautomaton/linuxautomaton/statedump.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/linuxautomaton/linuxautomaton/syscalls.py
+++ b/linuxautomaton/linuxautomaton/syscalls.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttng-analyses-record
+++ b/lttng-analyses-record
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttng-cputop
+++ b/lttng-cputop
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttng-iolatencyfreq
+++ b/lttng-iolatencyfreq
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttng-iolatencystats
+++ b/lttng-iolatencystats
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttng-iolatencytop
+++ b/lttng-iolatencytop
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttng-iolog
+++ b/lttng-iolog
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttng-iousagetop
+++ b/lttng-iousagetop
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttng-irqfreq
+++ b/lttng-irqfreq
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttng-irqlog
+++ b/lttng-irqlog
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttng-irqstats
+++ b/lttng-irqstats
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttng-memtop
+++ b/lttng-memtop
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttng-syscallstats
+++ b/lttng-syscallstats
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalyses/lttnganalyses/__init__.py
+++ b/lttnganalyses/lttnganalyses/__init__.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalyses/lttnganalyses/analysis.py
+++ b/lttnganalyses/lttnganalyses/analysis.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalyses/lttnganalyses/cputop.py
+++ b/lttnganalyses/lttnganalyses/cputop.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalyses/lttnganalyses/irq.py
+++ b/lttnganalyses/lttnganalyses/irq.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalyses/lttnganalyses/memtop.py
+++ b/lttnganalyses/lttnganalyses/memtop.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalyses/lttnganalyses/syscalls.py
+++ b/lttnganalyses/lttnganalyses/syscalls.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalysescli/lttnganalysescli/__init__.py
+++ b/lttnganalysescli/lttnganalysescli/__init__.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalysescli/lttnganalysescli/command.py
+++ b/lttnganalysescli/lttnganalysescli/command.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalysescli/lttnganalysescli/cputop.py
+++ b/lttnganalysescli/lttnganalysescli/cputop.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalysescli/lttnganalysescli/io.py
+++ b/lttnganalysescli/lttnganalysescli/io.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalysescli/lttnganalysescli/memtop.py
+++ b/lttnganalysescli/lttnganalysescli/memtop.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalysescli/lttnganalysescli/progressbar.py
+++ b/lttnganalysescli/lttnganalysescli/progressbar.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalysescli/lttnganalysescli/syscallstats.py
+++ b/lttnganalysescli/lttnganalysescli/syscallstats.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/old/cpu-dist.py
+++ b/old/cpu-dist.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2014 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2014 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/parser_generator.py
+++ b/parser_generator.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfosez@efficios.com>
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fixes a typo appearing in the author's email address present in the license header of most files in the repo.