### PR TITLE
IRQ Analysis rewrite and general Pythonification

### DIFF
--- a/linuxautomaton/linuxautomaton/automaton.py
+++ b/linuxautomaton/linuxautomaton/automaton.py
@@ -40,7 +40,6 @@ class State:
         self.syscalls = {}
         self.mm = MemoryManagement()
         self.ifaces = {}
-        self.interrupts = {}
         self.pending_syscalls = []
 
 

--- a/linuxautomaton/linuxautomaton/automaton.py
+++ b/linuxautomaton/linuxautomaton/automaton.py
@@ -41,6 +41,19 @@ class State:
         self.mm = MemoryManagement()
         self.ifaces = {}
         self.pending_syscalls = []
+        self._notification_cbs = {}
+
+    def _register_notification_cbs(self, cbs):
+        for name in cbs:
+            if name not in self._notification_cbs:
+                self._notification_cbs[name] = []
+
+            self._notification_cbs[name].append(cbs[name])
+
+    def _send_notification_cb(self, name, **kwargs):
+        if name in self._notification_cbs:
+            for cb in self._notification_cbs[name]:
+                cb(**kwargs)
 
 
 class Automaton:

--- a/linuxautomaton/linuxautomaton/automaton.py
+++ b/linuxautomaton/linuxautomaton/automaton.py
@@ -29,6 +29,7 @@ from .syscalls import SyscallsStateProvider
 from .statedump import StatedumpStateProvider
 from .block import BlockStateProvider
 from .net import NetStateProvider
+from .sv import MemoryManagement
 
 
 class State:
@@ -37,9 +38,8 @@ class State:
         self.tids = {}
         self.disks = {}
         self.syscalls = {}
-        self.mm = {}
+        self.mm = MemoryManagement()
         self.ifaces = {}
-        self.dirty_pages = {}
         self.interrupts = {}
         self.pending_syscalls = []
 

--- a/linuxautomaton/linuxautomaton/block.py
+++ b/linuxautomaton/linuxautomaton/block.py
@@ -107,7 +107,7 @@ class BlockStateProvider(sp.StateProvider):
                 self.tids[tid] = p
             else:
                 p = self.tids[tid]
-            if p.pid != -1 and p.tid != p.pid:
+            if p.pid is not None and p.tid != p.pid:
                 p = self.tids[p.pid]
             rq["pid"] = p
             # even rwbs means read, odd means write

--- a/linuxautomaton/linuxautomaton/common.py
+++ b/linuxautomaton/linuxautomaton/common.py
@@ -43,13 +43,13 @@ def kdev_major_minor(dev):
     MINORMASK = ((1 << MINORBITS) - 1)
     major = dev >> MINORBITS
     minor = dev & MINORMASK
-    return "(%d,%d)" % (major, minor)
+    return '(%d,%d)' % (major, minor)
 
 
 def get_disk(dev, disks):
     if dev not in disks:
         d = sv.Disk()
-        d.name = "%d" % dev
+        d.name = '%d' % dev
         d.prettyname = kdev_major_minor(dev)
         disks[dev] = d
     else:
@@ -59,26 +59,26 @@ def get_disk(dev, disks):
 
 def convert_size(size, padding_after=False, padding_before=False):
     if padding_after and size < 1024:
-        space_after = " "
+        space_after = ' '
     else:
-        space_after = ""
+        space_after = ''
     if padding_before and size < 1024:
-        space_before = " "
+        space_before = ' '
     else:
-        space_before = ""
+        space_before = ''
     if size <= 0:
-        return "0 " + space_before + "B" + space_after
-    size_name = ("B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+        return '0 ' + space_before + 'B' + space_after
+    size_name = ('B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB')
     i = int(math.floor(math.log(size, 1024)))
     p = math.pow(1024, i)
     s = round(size/p, 2)
     if (s > 0):
         try:
-            v = "%0.02f" % s
+            v = '%0.02f' % s
             return '%s %s%s%s' % (v, space_before, size_name[i], space_after)
         except:
             print(i, size_name)
-            raise Exception("Too big to be true")
+            raise Exception('Too big to be true')
     else:
         return '0 B'
 
@@ -116,8 +116,8 @@ def extract_timerange(handle, timerange, gmt):
     p = re.compile('^\[(?P<begin>.*),(?P<end>.*)\]$')
     if not p.match(timerange):
         return None
-    b = p.search(timerange).group("begin").strip()
-    e = p.search(timerange).group("end").strip()
+    b = p.search(timerange).group('begin').strip()
+    e = p.search(timerange).group('end').strip()
     begin = date_to_epoch_nsec(handle, b, gmt)
     if begin is None:
         return (None, None)
@@ -144,20 +144,20 @@ def date_to_epoch_nsec(handle, date, gmt):
     p4 = re.compile('^(?P<hour>\d\d):(?P<min>\d\d):(?P<sec>\d\d)$')
 
     if p1.match(date):
-        year = p1.search(date).group("year")
-        month = p1.search(date).group("mon")
-        day = p1.search(date).group("day")
-        hour = p1.search(date).group("hour")
-        minute = p1.search(date).group("min")
-        sec = p1.search(date).group("sec")
-        nsec = p1.search(date).group("nsec")
+        year = p1.search(date).group('year')
+        month = p1.search(date).group('mon')
+        day = p1.search(date).group('day')
+        hour = p1.search(date).group('hour')
+        minute = p1.search(date).group('min')
+        sec = p1.search(date).group('sec')
+        nsec = p1.search(date).group('nsec')
     elif p2.match(date):
-        year = p2.search(date).group("year")
-        month = p2.search(date).group("mon")
-        day = p2.search(date).group("day")
-        hour = p2.search(date).group("hour")
-        minute = p2.search(date).group("min")
-        sec = p2.search(date).group("sec")
+        year = p2.search(date).group('year')
+        month = p2.search(date).group('mon')
+        day = p2.search(date).group('day')
+        hour = p2.search(date).group('hour')
+        minute = p2.search(date).group('min')
+        sec = p2.search(date).group('sec')
         nsec = 0
     elif p3.match(date):
         d = trace_collection_date(handle)
@@ -168,10 +168,10 @@ def date_to_epoch_nsec(handle, date, gmt):
         year = d[0]
         month = d[1]
         day = d[2]
-        hour = p3.search(date).group("hour")
-        minute = p3.search(date).group("min")
-        sec = p3.search(date).group("sec")
-        nsec = p3.search(date).group("nsec")
+        hour = p3.search(date).group('hour')
+        minute = p3.search(date).group('min')
+        sec = p3.search(date).group('sec')
+        nsec = p3.search(date).group('nsec')
     elif p4.match(date):
         d = trace_collection_date(handle)
         if d is None:
@@ -181,9 +181,9 @@ def date_to_epoch_nsec(handle, date, gmt):
         year = d[0]
         month = d[1]
         day = d[2]
-        hour = p4.search(date).group("hour")
-        minute = p4.search(date).group("min")
-        sec = p4.search(date).group("sec")
+        hour = p4.search(date).group('hour')
+        minute = p4.search(date).group('min')
+        sec = p4.search(date).group('sec')
         nsec = 0
     else:
         return None
@@ -202,7 +202,7 @@ def process_date_args(command):
             extract_timerange(command._handle, command._arg_timerange,
                               command._arg_gmt)
         if command._arg_begin is None or command._arg_end is None:
-            print("Invalid timeformat")
+            print('Invalid timeformat')
             sys.exit(1)
     else:
         if command._arg_begin:
@@ -210,14 +210,14 @@ def process_date_args(command):
                                                     command._arg_begin,
                                                     command._arg_gmt)
             if command._arg_begin is None:
-                print("Invalid timeformat")
+                print('Invalid timeformat')
                 sys.exit(1)
         if command._arg_end:
             command._arg_end = date_to_epoch_nsec(command._handle,
                                                   command._arg_end,
                                                   command._arg_gmt)
             if command._arg_end is None:
-                print("Invalid timeformat")
+                print('Invalid timeformat')
                 sys.exit(1)
 
 
@@ -227,7 +227,7 @@ def ns_to_asctime(ns):
 
 def ns_to_hour(ns):
     d = time.localtime(ns/NSEC_PER_SEC)
-    return "%02d:%02d:%02d" % (d.tm_hour, d.tm_min, d.tm_sec)
+    return '%02d:%02d:%02d' % (d.tm_hour, d.tm_min, d.tm_sec)
 
 
 def ns_to_hour_nsec(ns, multi_day=False, gmt=False):
@@ -236,27 +236,27 @@ def ns_to_hour_nsec(ns, multi_day=False, gmt=False):
     else:
         d = time.localtime(ns/NSEC_PER_SEC)
     if multi_day:
-        return "%04d-%02d-%02d %02d:%02d:%02d.%09d" % (d.tm_year, d.tm_mon,
+        return '%04d-%02d-%02d %02d:%02d:%02d.%09d' % (d.tm_year, d.tm_mon,
                                                        d.tm_mday, d.tm_hour,
                                                        d.tm_min, d.tm_sec,
                                                        ns % NSEC_PER_SEC)
     else:
-        return "%02d:%02d:%02d.%09d" % (d.tm_hour, d.tm_min, d.tm_sec,
+        return '%02d:%02d:%02d.%09d' % (d.tm_hour, d.tm_min, d.tm_sec,
                                         ns % NSEC_PER_SEC)
 
 
 def ns_to_sec(ns):
-    return "%lu.%09u" % (ns/NSEC_PER_SEC, ns % NSEC_PER_SEC)
+    return '%lu.%09u' % (ns/NSEC_PER_SEC, ns % NSEC_PER_SEC)
 
 
 def ns_to_day(ns):
     d = time.localtime(ns/NSEC_PER_SEC)
-    return "%04d-%02d-%02d" % (d.tm_year, d.tm_mon, d.tm_mday)
+    return '%04d-%02d-%02d' % (d.tm_year, d.tm_mon, d.tm_mday)
 
 
 def sec_to_hour(ns):
     d = time.localtime(ns)
-    return "%02d:%02d:%02d" % (d.tm_hour, d.tm_min, d.tm_sec)
+    return '%02d:%02d:%02d' % (d.tm_hour, d.tm_min, d.tm_sec)
 
 
 def sec_to_nsec(sec):
@@ -264,35 +264,35 @@ def sec_to_nsec(sec):
 
 
 def seq_to_ipv4(ip):
-    return "{}.{}.{}.{}".format(ip[0], ip[1], ip[2], ip[3])
+    return '{}.{}.{}.{}'.format(ip[0], ip[1], ip[2], ip[3])
 
 
 def int_to_ipv4(ip):
-    return socket.inet_ntoa(struct.pack("!I", ip))
+    return socket.inet_ntoa(struct.pack('!I', ip))
 
 
 def str_to_bytes(value):
-    num = ""
-    unit = ""
+    num = ''
+    unit = ''
     for i in value:
-        if i.isdigit() or i == ".":
+        if i.isdigit() or i == '.':
             num = num + i
         elif i.isalnum():
             unit = unit + i
     num = float(num)
     if not unit:
         return int(num)
-    if unit in ["B"]:
+    if unit in ['B']:
         return int(num)
-    if unit in ["k", "K", "kB", "KB"]:
+    if unit in ['k', 'K', 'kB', 'KB']:
         return int(num * 1024)
-    if unit in ["m", "M", "mB", "MB"]:
+    if unit in ['m', 'M', 'mB', 'MB']:
         return int(num * 1024 * 1024)
-    if unit in ["g", "G", "gB", "GB"]:
+    if unit in ['g', 'G', 'gB', 'GB']:
         return int(num * 1024 * 1024 * 1024)
-    if unit in ["t", "T", "tB", "TB"]:
+    if unit in ['t', 'T', 'tB', 'TB']:
         return int(num * 1024 * 1024 * 1024 * 1024)
-    print("Unit", unit, "not understood")
+    print('Unit', unit, 'not understood')
     return None
 
 

--- a/linuxautomaton/linuxautomaton/common.py
+++ b/linuxautomaton/linuxautomaton/common.py
@@ -280,7 +280,7 @@ def str_to_bytes(value):
         elif i.isalnum():
             unit = unit + i
     num = float(num)
-    if len(unit) == 0:
+    if not unit:
         return int(num)
     if unit in ["B"]:
         return int(num)

--- a/linuxautomaton/linuxautomaton/common.py
+++ b/linuxautomaton/linuxautomaton/common.py
@@ -84,9 +84,9 @@ def convert_size(size, padding_after=False, padding_before=False):
 
 
 def is_multi_day_trace_collection(handle):
-    y = m = d = -1
+    y = m = d = None
     for h in handle.values():
-        if y == -1:
+        if y is None:
             y = time.localtime(h.timestamp_begin/NSEC_PER_SEC).tm_year
             m = time.localtime(h.timestamp_begin/NSEC_PER_SEC).tm_mon
             d = time.localtime(h.timestamp_begin/NSEC_PER_SEC).tm_mday

--- a/linuxautomaton/linuxautomaton/irq.py
+++ b/linuxautomaton/linuxautomaton/irq.py
@@ -84,17 +84,17 @@ class IrqStateProvider(sp.StateProvider):
         duration = i.stop_ts - i.start_ts
         if duration > irq_entry["max"]:
             irq_entry["max"] = duration
-        if irq_entry["min"] == -1 or duration < irq_entry["min"]:
+        if irq_entry["min"] is None or duration < irq_entry["min"]:
             irq_entry["min"] = duration
         irq_entry["count"] += 1
         irq_entry["total"] += duration
         # compute raise latency if applicable
-        if i.raise_ts == -1:
+        if i.raise_ts is None:
             return True
         latency = i.start_ts - i.raise_ts
         if latency > irq_entry["raise_max"]:
             irq_entry["raise_max"] = latency
-        if irq_entry["raise_min"] == -1 or latency < irq_entry["raise_min"]:
+        if irq_entry["raise_min"] is None or latency < irq_entry["raise_min"]:
             irq_entry["raise_min"] = latency
         irq_entry["raise_count"] += 1
         irq_entry["raise_total"] += latency

--- a/linuxautomaton/linuxautomaton/irq.py
+++ b/linuxautomaton/linuxautomaton/irq.py
@@ -99,6 +99,7 @@ class IrqStateProvider(sp.StateProvider):
         if cpu.current_softirqs[vec]:
             cpu.current_softirqs[vec][0].start_ts = event.timestamp
         else:
+            # SoftIRQ entry without a corresponding raise
             irq = sv.SoftIRQ.new_from_softirq_entry(event)
             cpu.current_softirqs[vec].append(irq)
 

--- a/linuxautomaton/linuxautomaton/irq.py
+++ b/linuxautomaton/linuxautomaton/irq.py
@@ -28,113 +28,66 @@ from linuxautomaton import sp, sv
 class IrqStateProvider(sp.StateProvider):
     def __init__(self, state):
         self.state = state
-        self.irq = state.interrupts
-        self.cpus = state.cpus
-        self.tids = state.tids
-        self.irq["hard_count"] = 0
-        self.irq["soft_count"] = 0
-        self.irq["hard-per-cpu"] = {}
-        self.irq["soft-per-cpu"] = {}
-        self.irq["raise-per-cpu"] = {}
-        self.irq["names"] = {}
-        self.irq["hard-irqs"] = {}
-        self.irq["soft-irqs"] = {}
-        self.irq["raise-latency"] = {}
-        self.irq["irq-list"] = []
         cbs = {
             'irq_handler_entry': self._process_irq_handler_entry,
             'irq_handler_exit': self._process_irq_handler_exit,
-            'softirq_entry': self._process_softirq_entry,
-            'softirq_exit': self._process_softirq_exit,
             'softirq_raise': self._process_softirq_raise,
+            'softirq_entry': self._process_softirq_entry,
+            'softirq_exit': self._process_softirq_exit
         }
         self._register_cbs(cbs)
 
     def process_event(self, ev):
         self._process_event_cb(ev)
 
-    def entry(self, event, irqclass, idfield):
-        cpu_id = event["cpu_id"]
-        i = sv.IRQ()
-        i.irqclass = irqclass
-        i.start_ts = event.timestamp
-        i.cpu_id = cpu_id
-        i.nr = event[idfield]
-        return i
+    def _get_cpu(self, cpu_id):
+        if cpu_id not in self.state.cpus:
+            self.state.cpus[cpu_id] = sv.CPU()
 
+        return self.state.cpus[cpu_id]
+
+    # Hard IRQs
     def _process_irq_handler_entry(self, event):
-        cpu_id = event["cpu_id"]
-        self.irq["names"][event["irq"]] = event["name"]
-        self.irq["hard_count"] += 1
-        i = self.entry(event, sv.IRQ.HARD_IRQ, "irq")
-        self.irq["hard-per-cpu"][cpu_id] = i
-
-    def _process_softirq_entry(self, event):
-        cpu_id = event["cpu_id"]
-        self.irq["soft_count"] += 1
-        i = self.entry(event, sv.IRQ.SOFT_IRQ, "vec")
-        self.irq["soft-per-cpu"][cpu_id] = i
-        if cpu_id in self.irq["raise-per-cpu"].keys() and \
-                self.irq["raise-per-cpu"][cpu_id] is not None and \
-                self.irq["raise-per-cpu"][cpu_id][1] == event["vec"]:
-                    i.raise_ts = self.irq["raise-per-cpu"][cpu_id][0]
-                    self.irq["raise-per-cpu"][cpu_id] = None
-
-    def compute_stats(self, irq_entry, i):
-        duration = i.stop_ts - i.start_ts
-        if duration > irq_entry["max"]:
-            irq_entry["max"] = duration
-        if irq_entry["min"] is None or duration < irq_entry["min"]:
-            irq_entry["min"] = duration
-        irq_entry["count"] += 1
-        irq_entry["total"] += duration
-        # compute raise latency if applicable
-        if i.raise_ts is None:
-            return True
-        latency = i.start_ts - i.raise_ts
-        if latency > irq_entry["raise_max"]:
-            irq_entry["raise_max"] = latency
-        if irq_entry["raise_min"] is None or latency < irq_entry["raise_min"]:
-            irq_entry["raise_min"] = latency
-        irq_entry["raise_count"] += 1
-        irq_entry["raise_total"] += latency
-        return True
-
-    def exit(self, event, idfield, per_cpu_key, irq_type):
-        cpu_id = event["cpu_id"]
-        if cpu_id not in self.irq[per_cpu_key].keys() or \
-                self.irq[per_cpu_key][cpu_id] is None:
-                    return
-        i = self.irq[per_cpu_key][cpu_id]
-        if i.nr != event[idfield]:
-            self.irq[per_cpu_key][cpu_id] = None
-            return
-        i.stop_ts = event.timestamp
-        if not i.nr in self.irq[irq_type].keys():
-            self.irq[irq_type][i.nr] = sv.IRQ.init_irq_instance()
-
-        # filter out max/min
-        duration = i.stop_ts - i.start_ts
-        if hasattr(self.state, "max") and self.state.max is not None and \
-                duration > self.state.max * 1000:
-            return False
-        if hasattr(self.state, "min") and self.state.min is not None and \
-                duration < self.state.min * 1000:
-            return False
-        self.irq[irq_type][i.nr]["list"].append(i)
-        self.compute_stats(self.irq[irq_type][i.nr], i)
-        self.irq["irq-list"].append(i)
-        return i
+        cpu = self._get_cpu(event["cpu_id"])
+        irq = sv.HardIRQ.new_from_irq_handler_entry(event)
+        cpu.current_hard_irq = irq
 
     def _process_irq_handler_exit(self, event):
-        i = self.exit(event, "irq", "hard-per-cpu", "hard-irqs")
-        if not i:
+        cpu = self._get_cpu(event["cpu_id"])
+        if cpu.current_hard_irq is None or \
+           cpu.current_hard_irq.id != event["irq"]:
+            cpu.current_hard_irq = None
             return
-        i.ret = event["ret"]
+
+        cpu.current_hard_irq.stop_ts = event.timestamp
+        cpu.current_hard_irq.ret = event["ret"]
+
+        # TODO: send notification to analysis, with current_hard_irq as payload
+        cpu.current_hard_irq = None
+
+    # Soft IRQs
+    def _process_softirq_raise(self, event):
+        cpu = self._get_cpu(event["cpu_id"])
+        cpu_id = event["cpu_id"]
+        irq = sv.SoftIRQ.new_from_softirq_raise(event)
+        self.state.cpus[cpu_id].current_soft_irq = irq
+
+    def _process_softirq_entry(self, event):
+        cpu = self._get_cpu(event["cpu_id"])
+        if cpu.current_soft_irq is not None and \
+           cpu.current_soft_irq.id == event["vec"]:
+            cpu.current_soft_irq.start_ts = event.timestamp
+        else:
+            cpu.current_soft_irq = sv.SoftIRQ.new_from_softirq_entry(event)
 
     def _process_softirq_exit(self, event):
-        self.exit(event, "vec", "soft-per-cpu", "soft-irqs")
+        cpu = self._get_cpu(event["cpu_id"])
+        if cpu.current_soft_irq is None or \
+           cpu.current_soft_irq.id != event["vec"]:
+            cpu.current_soft_irq = None
+            return
 
-    def _process_softirq_raise(self, event):
-        cpu_id = event["cpu_id"]
-        self.irq["raise-per-cpu"][cpu_id] = ((event.timestamp, event["vec"]))
+        cpu.current_soft_irq.stop_ts = event.timestamp
+
+        # TODO: send notification to analysis, with current_soft_irq as payload
+        cpu.current_soft_irq = None

--- a/linuxautomaton/linuxautomaton/irq.py
+++ b/linuxautomaton/linuxautomaton/irq.py
@@ -43,7 +43,7 @@ class IrqStateProvider(sp.StateProvider):
 
     def _get_cpu(self, cpu_id):
         if cpu_id not in self.state.cpus:
-            self.state.cpus[cpu_id] = sv.CPU()
+            self.state.cpus[cpu_id] = sv.CPU(cpu_id)
 
         return self.state.cpus[cpu_id]
 

--- a/linuxautomaton/linuxautomaton/irq.py
+++ b/linuxautomaton/linuxautomaton/irq.py
@@ -48,19 +48,19 @@ class IrqStateProvider(sp.StateProvider):
 
     # Hard IRQs
     def _process_irq_handler_entry(self, event):
-        cpu = self._get_cpu(event["cpu_id"])
+        cpu = self._get_cpu(event['cpu_id'])
         irq = sv.HardIRQ.new_from_irq_handler_entry(event)
         cpu.current_hard_irq = irq
 
     def _process_irq_handler_exit(self, event):
-        cpu = self._get_cpu(event["cpu_id"])
+        cpu = self._get_cpu(event['cpu_id'])
         if cpu.current_hard_irq is None or \
-           cpu.current_hard_irq.id != event["irq"]:
+           cpu.current_hard_irq.id != event['irq']:
             cpu.current_hard_irq = None
             return
 
         cpu.current_hard_irq.stop_ts = event.timestamp
-        cpu.current_hard_irq.ret = event["ret"]
+        cpu.current_hard_irq.ret = event['ret']
 
         self.state._send_notification_cb('irq_handler_exit',
                                          hard_irq=cpu.current_hard_irq)
@@ -68,23 +68,23 @@ class IrqStateProvider(sp.StateProvider):
 
     # Soft IRQs
     def _process_softirq_raise(self, event):
-        cpu = self._get_cpu(event["cpu_id"])
-        cpu_id = event["cpu_id"]
+        cpu = self._get_cpu(event['cpu_id'])
+        cpu_id = event['cpu_id']
         irq = sv.SoftIRQ.new_from_softirq_raise(event)
         self.state.cpus[cpu_id].current_soft_irq = irq
 
     def _process_softirq_entry(self, event):
-        cpu = self._get_cpu(event["cpu_id"])
+        cpu = self._get_cpu(event['cpu_id'])
         if cpu.current_soft_irq is not None and \
-           cpu.current_soft_irq.id == event["vec"]:
+           cpu.current_soft_irq.id == event['vec']:
             cpu.current_soft_irq.start_ts = event.timestamp
         else:
             cpu.current_soft_irq = sv.SoftIRQ.new_from_softirq_entry(event)
 
     def _process_softirq_exit(self, event):
-        cpu = self._get_cpu(event["cpu_id"])
+        cpu = self._get_cpu(event['cpu_id'])
         if cpu.current_soft_irq is None or \
-           cpu.current_soft_irq.id != event["vec"]:
+           cpu.current_soft_irq.id != event['vec']:
             cpu.current_soft_irq = None
             return
 

--- a/linuxautomaton/linuxautomaton/irq.py
+++ b/linuxautomaton/linuxautomaton/irq.py
@@ -62,7 +62,8 @@ class IrqStateProvider(sp.StateProvider):
         cpu.current_hard_irq.stop_ts = event.timestamp
         cpu.current_hard_irq.ret = event["ret"]
 
-        # TODO: send notification to analysis, with current_hard_irq as payload
+        self.state._send_notification_cb('irq_handler_exit',
+                                         hard_irq=cpu.current_hard_irq)
         cpu.current_hard_irq = None
 
     # Soft IRQs
@@ -89,5 +90,6 @@ class IrqStateProvider(sp.StateProvider):
 
         cpu.current_soft_irq.stop_ts = event.timestamp
 
-        # TODO: send notification to analysis, with current_soft_irq as payload
+        self.state._send_notification_cb('softirq_exit',
+                                         soft_irq=cpu.current_soft_irq)
         cpu.current_soft_irq = None

--- a/linuxautomaton/linuxautomaton/irq.py
+++ b/linuxautomaton/linuxautomaton/irq.py
@@ -55,8 +55,7 @@ class IrqStateProvider(sp.StateProvider):
 
         self.state._send_notification_cb('irq_handler_entry',
                                          id=irq.id,
-                                         irq_name=event['name']
-        )
+                                         irq_name=event['name'])
 
     def _process_irq_handler_exit(self, event):
         cpu = self._get_cpu(event['cpu_id'])
@@ -112,6 +111,5 @@ class IrqStateProvider(sp.StateProvider):
 
         cpu.current_softirqs[vec][0].stop_ts = event.timestamp
         self.state._send_notification_cb('softirq_exit',
-                                         softirq=cpu.current_softirqs[vec][0]
-        )
+                                         softirq=cpu.current_softirqs[vec][0])
         cpu.current_softirqs[vec].pop(0)

--- a/linuxautomaton/linuxautomaton/irq.py
+++ b/linuxautomaton/linuxautomaton/irq.py
@@ -3,6 +3,7 @@
 # The MIT License (MIT)
 #
 # Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
+#               2015 - Antoine Busque <abusque@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/linuxautomaton/linuxautomaton/mem.py
+++ b/linuxautomaton/linuxautomaton/mem.py
@@ -43,7 +43,7 @@ class MemStateProvider(sp.StateProvider):
             return None
 
         cpu = self.state.cpus[cpu_id]
-        if cpu.current_tid == -1:
+        if cpu.current_tid is None:
             return None
 
         return self.state.tids[cpu.current_tid]

--- a/linuxautomaton/linuxautomaton/mem.py
+++ b/linuxautomaton/linuxautomaton/mem.py
@@ -28,23 +28,9 @@ from linuxautomaton import sp
 class MemStateProvider(sp.StateProvider):
     def __init__(self, state):
         self.state = state
-        self.mm = state.mm
-        self.cpus = state.cpus
-        self.tids = state.tids
-        self.dirty_pages = state.dirty_pages
-        self.mm["allocated_pages"] = 0
-        self.mm["freed_pages"] = 0
-        self.mm["count"] = 0
-        self.mm["dirty"] = 0
-        self.dirty_pages["pages"] = []
-        self.dirty_pages["global_nr_dirty"] = -1
-        self.dirty_pages["base_nr_dirty"] = -1
         cbs = {
             'mm_page_alloc': self._process_mm_page_alloc,
-            'mm_page_free': self._process_mm_page_free,
-            'block_dirty_buffer': self._process_block_dirty_buffer,
-            'writeback_global_dirty_state':
-            self._process_writeback_global_dirty_state,
+            'mm_page_free': self._process_mm_page_free
         }
         self._register_cbs(cbs)
 
@@ -53,56 +39,44 @@ class MemStateProvider(sp.StateProvider):
 
     def _get_current_proc(self, event):
         cpu_id = event["cpu_id"]
-        if cpu_id not in self.cpus:
+        if cpu_id not in self.state.cpus:
             return None
-        c = self.cpus[cpu_id]
-        if c.current_tid == -1:
+
+        cpu = self.state.cpus[cpu_id]
+        if cpu.current_tid == -1:
             return None
-        return self.tids[c.current_tid]
+
+        return self.state.tids[cpu.current_tid]
 
     def _process_mm_page_alloc(self, event):
-        self.mm["count"] += 1
-        self.mm["allocated_pages"] += 1
-        for p in self.tids.values():
-            if len(p.current_syscall.keys()) == 0:
+        self.state.mm.page_count += 1
+
+        # Increment the number of pages allocated during the execution
+        # of all currently pending syscalls
+        for process in self.state.tids.values():
+            if not process.current_syscall:
                 continue
-            if "alloc" not in p.current_syscall.keys():
-                p.current_syscall["alloc"] = 1
+
+            if "pages_allocated" not in process.current_syscall:
+                process.current_syscall["pages_allocated"] = 1
             else:
-                p.current_syscall["alloc"] += 1
-        t = self._get_current_proc(event)
-        if t is None:
+                process.current_syscall["pages_allocated"] += 1
+
+        current_process = self._get_current_proc(event)
+        if current_process is None:
             return
-        t.allocated_pages += 1
+
+        current_process.allocated_pages += 1
 
     def _process_mm_page_free(self, event):
-        self.mm["freed_pages"] += 1
-        if self.mm["count"] == 0:
+        if self.state.mm.page_count == 0:
             return
-        self.mm["count"] -= 1
-        t = self._get_current_proc(event)
-        if t is None:
-            return
-        t.freed_pages += 1
 
-    def _process_block_dirty_buffer(self, event):
-        self.mm["dirty"] += 1
-        if event["cpu_id"] not in self.cpus.keys():
-            return
-        c = self.cpus[event["cpu_id"]]
-        if c.current_tid <= 0:
-            return
-        p = self.tids[c.current_tid]
-        current_syscall = self.tids[c.current_tid].current_syscall
-        if len(current_syscall.keys()) == 0:
-            return
-        if self.dirty_pages is None:
-            return
-        if "fd" in current_syscall.keys():
-            self.dirty_pages["pages"].append((p, current_syscall["name"],
-                                              current_syscall["fd"].filename,
-                                              current_syscall["fd"].fd))
-        return
+        self.state.mm.page_count -= 1
 
-    def _process_writeback_global_dirty_state(self, event):
-        self.mm["dirty"] = 0
+        # Track the number of pages freed by the currently executing process
+        current_process = self._get_current_proc(event)
+        if current_process is None:
+            return
+
+        current_process.freed_pages += 1

--- a/linuxautomaton/linuxautomaton/mem.py
+++ b/linuxautomaton/linuxautomaton/mem.py
@@ -38,7 +38,7 @@ class MemStateProvider(sp.StateProvider):
         self._process_event_cb(ev)
 
     def _get_current_proc(self, event):
-        cpu_id = event["cpu_id"]
+        cpu_id = event['cpu_id']
         if cpu_id not in self.state.cpus:
             return None
 
@@ -57,10 +57,10 @@ class MemStateProvider(sp.StateProvider):
             if not process.current_syscall:
                 continue
 
-            if "pages_allocated" not in process.current_syscall:
-                process.current_syscall["pages_allocated"] = 1
+            if 'pages_allocated' not in process.current_syscall:
+                process.current_syscall['pages_allocated'] = 1
             else:
-                process.current_syscall["pages_allocated"] += 1
+                process.current_syscall['pages_allocated'] += 1
 
         current_process = self._get_current_proc(event)
         if current_process is None:

--- a/linuxautomaton/linuxautomaton/net.py
+++ b/linuxautomaton/linuxautomaton/net.py
@@ -61,7 +61,7 @@ class NetStateProvider(sp.StateProvider):
         if cpu_id not in self.cpus.keys():
             return
         c = self.cpus[cpu_id]
-        if c.current_tid == -1:
+        if c.current_tid is None:
             return
         t = self.tids[c.current_tid]
         if not t.current_syscall:

--- a/linuxautomaton/linuxautomaton/net.py
+++ b/linuxautomaton/linuxautomaton/net.py
@@ -50,9 +50,9 @@ class NetStateProvider(sp.StateProvider):
         return d
 
     def _process_net_dev_xmit(self, event):
-        dev = event["name"]
-        sent_len = event["len"]
-        cpu_id = event["cpu_id"]
+        dev = event['name']
+        sent_len = event['len']
+        cpu_id = event['cpu_id']
 
         d = self.get_dev(dev)
         d.send_packets += 1
@@ -66,13 +66,13 @@ class NetStateProvider(sp.StateProvider):
         t = self.tids[c.current_tid]
         if not t.current_syscall:
             return
-        if t.current_syscall["name"] in sv.SyscallConsts.WRITE_SYSCALLS:
-            if t.current_syscall["fd"].fdtype == sv.FDType.unknown:
-                t.current_syscall["fd"].fdtype = sv.FDType.maybe_net
+        if t.current_syscall['name'] in sv.SyscallConsts.WRITE_SYSCALLS:
+            if t.current_syscall['fd'].fdtype == sv.FDType.unknown:
+                t.current_syscall['fd'].fdtype = sv.FDType.maybe_net
 
     def _process_netif_receive_skb(self, event):
-        dev = event["name"]
-        recv_len = event["len"]
+        dev = event['name']
+        recv_len = event['len']
 
         d = self.get_dev(dev)
         d.recv_packets += 1

--- a/linuxautomaton/linuxautomaton/sched.py
+++ b/linuxautomaton/linuxautomaton/sched.py
@@ -54,7 +54,7 @@ class SchedStateProvider(sp.StateProvider):
                 c.current_tid = next_tid
             else:
                 c.start_task_ns = 0
-                c.current_tid = -1
+                c.current_tid = None
         else:
             self.add_cpu(cpu_id, ts, next_tid)
         for context in event.keys():

--- a/linuxautomaton/linuxautomaton/sched.py
+++ b/linuxautomaton/linuxautomaton/sched.py
@@ -58,7 +58,7 @@ class SchedStateProvider(sp.StateProvider):
         else:
             self.add_cpu(cpu_id, ts, next_tid)
         for context in event.keys():
-            if context.startswith("perf_"):
+            if context.startswith('perf_'):
                 c.perf[context] = event[context]
 
     def add_cpu(self, cpu_id, ts, next_tid):
@@ -86,7 +86,7 @@ class SchedStateProvider(sp.StateProvider):
             # perf PMU counters checks
             for context in event.field_list_with_scope(
                     CTFScope.STREAM_EVENT_CONTEXT):
-                if context.startswith("perf_"):
+                if context.startswith('perf_'):
                     if context not in c.perf.keys():
                         c.perf[context] = event[context]
                     # add the difference between the last known value
@@ -113,18 +113,18 @@ class SchedStateProvider(sp.StateProvider):
             p.comm = next_comm
         p.last_sched = ts
         for q in c.wakeup_queue:
-            if q["task"] == p:
-                ret["sched_latency"] = ts - q["ts"]
-                ret["next_tid"] = next_tid
+            if q['task'] == p:
+                ret['sched_latency'] = ts - q['ts']
+                ret['next_tid'] = next_tid
                 c.wakeup_queue.remove(q)
         return ret
 
     def _process_sched_switch(self, event):
         """Handle sched_switch event, returns a dict of changed values"""
-        prev_tid = event["prev_tid"]
-        next_comm = event["next_comm"]
-        next_tid = event["next_tid"]
-        cpu_id = event["cpu_id"]
+        prev_tid = event['prev_tid']
+        next_comm = event['next_comm']
+        next_tid = event['next_tid']
+        cpu_id = event['cpu_id']
         ret = {}
 
         self.sched_switch_per_tid(event.timestamp, prev_tid,
@@ -139,11 +139,11 @@ class SchedStateProvider(sp.StateProvider):
         return ret
 
     def _process_sched_migrate_task(self, event):
-        tid = event["tid"]
+        tid = event['tid']
         if tid not in self.state.tids:
             p = sv.Process()
             p.tid = tid
-            p.comm = event["comm"]
+            p.comm = event['comm']
             self.state.tids[tid] = p
         else:
             p = self.state.tids[tid]
@@ -151,8 +151,8 @@ class SchedStateProvider(sp.StateProvider):
 
     def _process_sched_wakeup(self, event):
         """Stores the sched_wakeup infos to compute scheduling latencies"""
-        target_cpu = event["target_cpu"]
-        tid = event["tid"]
+        target_cpu = event['target_cpu']
+        tid = event['tid']
         if target_cpu not in self.state.cpus.keys():
             c = sv.CPU()
             c.cpu_id = target_cpu
@@ -166,7 +166,7 @@ class SchedStateProvider(sp.StateProvider):
             self.state.tids[tid] = p
         else:
             p = self.state.tids[tid]
-        c.wakeup_queue.append({"ts": event.timestamp, "task": p})
+        c.wakeup_queue.append({'ts': event.timestamp, 'task': p})
 
     def fix_process(self, name, tid, pid):
         if tid not in self.state.tids:
@@ -195,12 +195,12 @@ class SchedStateProvider(sp.StateProvider):
         return f
 
     def _process_sched_process_fork(self, event):
-        child_tid = event["child_tid"]
-        child_pid = event["child_pid"]
-        child_comm = event["child_comm"]
-        parent_pid = event["parent_pid"]
-        parent_tid = event["parent_pid"]
-        parent_comm = event["parent_comm"]
+        child_tid = event['child_tid']
+        child_pid = event['child_pid']
+        child_comm = event['child_comm']
+        parent_pid = event['parent_pid']
+        parent_tid = event['parent_pid']
+        parent_comm = event['parent_comm']
         f = sv.Process()
         f.tid = child_tid
         f.pid = child_pid
@@ -216,15 +216,15 @@ class SchedStateProvider(sp.StateProvider):
         self.state.tids[child_tid] = f
 
     def _process_sched_process_exec(self, event):
-        tid = event["tid"]
+        tid = event['tid']
         if tid not in self.state.tids:
             p = sv.Process()
             p.tid = tid
             self.state.tids[tid] = p
         else:
             p = self.state.tids[tid]
-        if "procname" in event.keys():
-            p.comm = event["procname"]
+        if 'procname' in event.keys():
+            p.comm = event['procname']
         toremove = []
         for fd in p.fds.keys():
             if p.fds[fd].cloexec == 1:

--- a/linuxautomaton/linuxautomaton/sched.py
+++ b/linuxautomaton/linuxautomaton/sched.py
@@ -62,8 +62,7 @@ class SchedStateProvider(sp.StateProvider):
                 c.perf[context] = event[context]
 
     def add_cpu(self, cpu_id, ts, next_tid):
-        c = sv.CPU()
-        c.cpu_id = cpu_id
+        c = sv.CPU(cpu_id)
         c.current_tid = next_tid
         # when we schedule a real task (not swapper)
         c.start_task_ns = ts
@@ -154,8 +153,7 @@ class SchedStateProvider(sp.StateProvider):
         target_cpu = event['target_cpu']
         tid = event['tid']
         if target_cpu not in self.state.cpus.keys():
-            c = sv.CPU()
-            c.cpu_id = target_cpu
+            c = sv.CPU(target_cpu)
             self.state.cpus[target_cpu] = c
         else:
             c = self.state.cpus[target_cpu]

--- a/linuxautomaton/linuxautomaton/sched.py
+++ b/linuxautomaton/linuxautomaton/sched.py
@@ -29,9 +29,6 @@ from babeltrace import CTFScope
 class SchedStateProvider(sp.StateProvider):
     def __init__(self, state):
         self.state = state
-        self.cpus = state.cpus
-        self.tids = state.tids
-        self.dirty_pages = state.dirty_pages
         cbs = {
             'sched_switch': self._process_sched_switch,
             'sched_migrate_task': self._process_sched_migrate_task,
@@ -47,8 +44,8 @@ class SchedStateProvider(sp.StateProvider):
 
     def sched_switch_per_cpu(self, cpu_id, ts, next_tid, event):
         """Compute per-cpu usage"""
-        if cpu_id in self.cpus:
-            c = self.cpus[cpu_id]
+        if cpu_id in self.state.cpus:
+            c = self.state.cpus[cpu_id]
             if c.start_task_ns != 0:
                 c.cpu_ns += ts - c.start_task_ns
             # exclude swapper process
@@ -71,19 +68,19 @@ class SchedStateProvider(sp.StateProvider):
         # when we schedule a real task (not swapper)
         c.start_task_ns = ts
         # first activity on the sv.CPU
-        self.cpus[cpu_id] = c
-        self.cpus[cpu_id].total_per_cpu_pc_list = []
+        self.state.cpus[cpu_id] = c
+        self.state.cpus[cpu_id].total_per_cpu_pc_list = []
 
     def sched_switch_per_tid(self, ts, prev_tid, next_tid,
                              next_comm, cpu_id, event, ret):
         """Compute per-tid usage"""
         # if we don't know yet the sv.CPU, skip this
-        if cpu_id not in self.cpus.keys():
+        if cpu_id not in self.state.cpus.keys():
             self.add_cpu(cpu_id, ts, next_tid)
-        c = self.cpus[cpu_id]
+        c = self.state.cpus[cpu_id]
         # per-tid usage
-        if prev_tid in self.tids:
-            p = self.tids[prev_tid]
+        if prev_tid in self.state.tids:
+            p = self.state.tids[prev_tid]
             if p.last_sched is not None:
                 p.cpu_ns += (ts - p.last_sched)
             # perf PMU counters checks
@@ -106,13 +103,13 @@ class SchedStateProvider(sp.StateProvider):
         if next_tid == 0:
             return ret
 
-        if next_tid not in self.tids:
+        if next_tid not in self.state.tids:
             p = sv.Process()
             p.tid = next_tid
             p.comm = next_comm
-            self.tids[next_tid] = p
+            self.state.tids[next_tid] = p
         else:
-            p = self.tids[next_tid]
+            p = self.state.tids[next_tid]
             p.comm = next_comm
         p.last_sched = ts
         for q in c.wakeup_queue:
@@ -121,55 +118,6 @@ class SchedStateProvider(sp.StateProvider):
                 ret["next_tid"] = next_tid
                 c.wakeup_queue.remove(q)
         return ret
-
-    def clear_dirty_pages(self, to_clean, reason):
-        cleaned = []
-        if to_clean > len(self.dirty_pages["pages"]):
-            to_clean = len(self.dirty_pages["pages"])
-        for i in range(to_clean):
-            a = self.dirty_pages["pages"].pop(0)
-            cleaned.append(a)
-
-        # don't account background kernel threads emptying the
-        # page cache
-        if reason == "counter":
-            return
-
-        # flag all processes with a syscall in progress
-        for p in self.tids.values():
-            if len(p.current_syscall.keys()) == 0:
-                continue
-            p.current_syscall["pages_cleared"] = cleaned
-        return
-
-    def track_dirty_pages(self, event):
-        if "pages" not in self.dirty_pages.keys():
-            return
-        if "nr_dirty" not in event.keys():
-            # if the context is not available, only keep the
-            # last 1000 pages inserted (arbitrary)
-            if len(self.dirty_pages["pages"]) > 1000:
-                for i in range(len(self.dirty_pages["pages"]) - 1000):
-                    self.dirty_pages["pages"].pop(0)
-            return
-
-        nr = event["nr_dirty"]
-
-        if self.dirty_pages["global_nr_dirty"] == -1:
-            self.dirty_pages["global_nr_dirty"] = nr
-            self.dirty_pages["base_nr_dirty"] = nr
-            return
-
-        # only cleanup when the counter goes down
-        if nr >= self.dirty_pages["global_nr_dirty"]:
-            self.dirty_pages["global_nr_dirty"] = nr
-            return
-
-        if nr <= self.dirty_pages["base_nr_dirty"]:
-            self.dirty_pages["base_nr_dirty"] = nr
-            self.dirty_pages["global_nr_dirty"] = nr
-
-        self.dirty_pages["global_nr_dirty"] = nr
 
     def _process_sched_switch(self, event):
         """Handle sched_switch event, returns a dict of changed values"""
@@ -186,57 +134,56 @@ class SchedStateProvider(sp.StateProvider):
         # the per-tid analysis
         self.sched_switch_per_cpu(cpu_id, event.timestamp, next_tid, event)
         if next_tid > 0:
-            self.tids[next_tid].prev_tid = prev_tid
-        self.track_dirty_pages(event)
+            self.state.tids[next_tid].prev_tid = prev_tid
 
         return ret
 
     def _process_sched_migrate_task(self, event):
         tid = event["tid"]
-        if tid not in self.tids:
+        if tid not in self.state.tids:
             p = sv.Process()
             p.tid = tid
             p.comm = event["comm"]
-            self.tids[tid] = p
+            self.state.tids[tid] = p
         else:
-            p = self.tids[tid]
+            p = self.state.tids[tid]
         p.migrate_count += 1
 
     def _process_sched_wakeup(self, event):
         """Stores the sched_wakeup infos to compute scheduling latencies"""
         target_cpu = event["target_cpu"]
         tid = event["tid"]
-        if target_cpu not in self.cpus.keys():
+        if target_cpu not in self.state.cpus.keys():
             c = sv.CPU()
             c.cpu_id = target_cpu
-            self.cpus[target_cpu] = c
+            self.state.cpus[target_cpu] = c
         else:
-            c = self.cpus[target_cpu]
+            c = self.state.cpus[target_cpu]
 
-        if tid not in self.tids:
+        if tid not in self.state.tids:
             p = sv.Process()
             p.tid = tid
-            self.tids[tid] = p
+            self.state.tids[tid] = p
         else:
-            p = self.tids[tid]
+            p = self.state.tids[tid]
         c.wakeup_queue.append({"ts": event.timestamp, "task": p})
 
     def fix_process(self, name, tid, pid):
-        if tid not in self.tids:
+        if tid not in self.state.tids:
             p = sv.Process()
             p.tid = tid
-            self.tids[tid] = p
+            self.state.tids[tid] = p
         else:
-            p = self.tids[tid]
+            p = self.state.tids[tid]
         p.pid = pid
         p.comm = name
 
-        if pid not in self.tids:
+        if pid not in self.state.tids:
             p = sv.Process()
             p.tid = pid
-            self.tids[pid] = p
+            self.state.tids[pid] = p
         else:
-            p = self.tids[pid]
+            p = self.state.tids[pid]
         p.pid = pid
         p.comm = name
 
@@ -261,21 +208,21 @@ class SchedStateProvider(sp.StateProvider):
 
         # make sure the parent exists
         self.fix_process(parent_comm, parent_tid, parent_pid)
-        p = self.tids[parent_pid]
+        p = self.state.tids[parent_pid]
         for fd in p.fds.keys():
             f.fds[fd] = self.dup_fd(p.fds[fd])
             f.fds[fd].parent = parent_pid
 
-        self.tids[child_tid] = f
+        self.state.tids[child_tid] = f
 
     def _process_sched_process_exec(self, event):
         tid = event["tid"]
-        if tid not in self.tids:
+        if tid not in self.state.tids:
             p = sv.Process()
             p.tid = tid
-            self.tids[tid] = p
+            self.state.tids[tid] = p
         else:
-            p = self.tids[tid]
+            p = self.state.tids[tid]
         if "procname" in event.keys():
             p.comm = event["procname"]
         toremove = []

--- a/linuxautomaton/linuxautomaton/sp.py
+++ b/linuxautomaton/linuxautomaton/sp.py
@@ -36,10 +36,10 @@ class StateProvider:
         if name in self._cbs:
             self._cbs[name](ev)
         # for now we process all the syscalls at the same place
-        if "syscall_entry" in self._cbs and \
+        elif "syscall_entry" in self._cbs and \
                 (name.startswith("sys_") or name.startswith("syscall_entry_")):
             self._cbs["syscall_entry"](ev)
-        if "syscall_exit" in self._cbs and \
+        elif "syscall_exit" in self._cbs and \
                 (name.startswith("exit_syscall") or
                  name.startswith("syscall_exit_")):
             self._cbs["syscall_exit"](ev)

--- a/linuxautomaton/linuxautomaton/sp.py
+++ b/linuxautomaton/linuxautomaton/sp.py
@@ -36,10 +36,10 @@ class StateProvider:
         if name in self._cbs:
             self._cbs[name](ev)
         # for now we process all the syscalls at the same place
-        elif "syscall_entry" in self._cbs and \
-                (name.startswith("sys_") or name.startswith("syscall_entry_")):
-            self._cbs["syscall_entry"](ev)
-        elif "syscall_exit" in self._cbs and \
-                (name.startswith("exit_syscall") or
-                 name.startswith("syscall_exit_")):
-            self._cbs["syscall_exit"](ev)
+        elif 'syscall_entry' in self._cbs and \
+                (name.startswith('sys_') or name.startswith('syscall_entry_')):
+            self._cbs['syscall_entry'](ev)
+        elif 'syscall_exit' in self._cbs and \
+                (name.startswith('exit_syscall') or
+                 name.startswith('syscall_exit_')):
+            self._cbs['syscall_exit'](ev)

--- a/linuxautomaton/linuxautomaton/statedump.py
+++ b/linuxautomaton/linuxautomaton/statedump.py
@@ -52,7 +52,7 @@ class StatedumpStateProvider(sp.StateProvider):
                     parent.chrono_fds[fd] = p.chrono_fds[fd]
                 else:
                     # best effort to fix the filename
-                    if len(parent.fds[fd].filename) == 0:
+                    if not parent.fds[fd].filename:
                         parent.fds[fd].filename = p.fds[fd].filename
                         chrono_fd = parent.chrono_fds[fd]
                         last_ts = next(reversed(chrono_fd))
@@ -74,7 +74,7 @@ class StatedumpStateProvider(sp.StateProvider):
                     parent.closed_fds[fd] = p.closed_fds[fd]
                 else:
                     # best effort to fix the filename
-                    if len(parent.closed_fds[fd].name) == 0:
+                    if not parent.closed_fds[fd].name:
                         parent.closed_fds[fd].name = p.closed_fds[fd].name
                     # merge the values as they are for the same sv.FD
                     parent.closed_fds[fd].read += p.closed_fds[fd].read

--- a/linuxautomaton/linuxautomaton/statedump.py
+++ b/linuxautomaton/linuxautomaton/statedump.py
@@ -56,7 +56,7 @@ class StatedumpStateProvider(sp.StateProvider):
                         parent.fds[fd].filename = p.fds[fd].filename
                         chrono_fd = parent.chrono_fds[fd]
                         last_ts = next(reversed(chrono_fd))
-                        chrono_fd[last_ts]["filename"] = p.fds[fd].filename
+                        chrono_fd[last_ts]['filename'] = p.fds[fd].filename
                     # merge the values as they are for the same sv.FD
                     parent.fds[fd].net_read += p.fds[fd].net_read
                     parent.fds[fd].net_write += p.fds[fd].net_write
@@ -84,9 +84,9 @@ class StatedumpStateProvider(sp.StateProvider):
                 p.closed_fds.pop(fd, None)
 
     def _process_lttng_statedump_process_state(self, event):
-        tid = event["tid"]
-        pid = event["pid"]
-        name = event["name"]
+        tid = event['tid']
+        pid = event['pid']
+        name = event['name']
         if tid not in self.tids:
             p = sv.Process()
             p.tid = tid
@@ -113,9 +113,9 @@ class StatedumpStateProvider(sp.StateProvider):
             self.merge_fd_dict(p, parent)
 
     def _process_lttng_statedump_file_descriptor(self, event):
-        pid = event["pid"]
-        fd = event["fd"]
-        filename = event["filename"]
+        pid = event['pid']
+        fd = event['fd']
+        filename = event['filename']
 
         if pid not in self.tids:
             p = sv.Process()
@@ -141,5 +141,5 @@ class StatedumpStateProvider(sp.StateProvider):
         p.track_chrono_fd(fd, filename, fdtype, event.timestamp)
 
     def _process_lttng_statedump_block_device(self, event):
-        d = common.get_disk(event["dev"], self.disks)
-        d.prettyname = event["diskname"]
+        d = common.get_disk(event['dev'], self.disks)
+        d.prettyname = event['diskname']

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -32,8 +32,8 @@ class StateVariable:
 
 class Process():
     def __init__(self):
-        self.tid = -1
-        self.pid = -1
+        self.tid = None
+        self.pid = None
         self.comm = ""
         # indexed by fd
         self.fds = {}
@@ -66,7 +66,7 @@ class Process():
         # last TS where the process was scheduled in
         self.last_sched = None
         # the process scheduled before this one
-        self.prev_tid = -1
+        self.prev_tid = None
         # indexed by syscall_name
         self.syscalls = {}
         self.perf = {}
@@ -95,9 +95,9 @@ class Process():
 
 class CPU():
     def __init__(self):
-        self.cpu_id = -1
+        self.cpu_id = None
         self.cpu_ns = 0
-        self.current_tid = -1
+        self.current_tid = None
         self.start_task_ns = 0
         self.perf = {}
         self.wakeup_queue = []
@@ -174,12 +174,12 @@ class FDType():
 class FD():
     def __init__(self):
         self.filename = ""
-        self.fd = -1
+        self.fd = None
         # address family
         self.family = socket.AF_UNSPEC
         self.fdtype = FDType.unknown
         # if FD was inherited, parent PID
-        self.parent = -1
+        self.parent = None
         self.init_counts()
 
     def init_counts(self):
@@ -218,23 +218,23 @@ class IRQ():
                   9: "RCU_SOFTIRQ"}
 
     def __init__(self):
-        self.nr = -1
+        self.nr = None
         self.irqclass = 0
-        self.start_ts = -1
-        self.stop_ts = -1
-        self.raise_ts = -1
-        self.cpu_id = -1
+        self.start_ts = None
+        self.stop_ts = None
+        self.raise_ts = None
+        self.cpu_id = None
 
     # used to track statistics about individual IRQs
     def init_irq_instance():
         irq = {}
         irq["list"] = []
         irq["max"] = 0
-        irq["min"] = -1
+        irq["min"] = None
         irq["count"] = 0
         irq["total"] = 0
         irq["raise_max"] = 0
-        irq["raise_min"] = -1
+        irq["raise_min"] = None
         irq["raise_count"] = 0
         irq["raise_total"] = 0
         return irq

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -103,6 +103,11 @@ class CPU():
         self.wakeup_queue = []
 
 
+class MemoryManagement():
+    def __init__(self):
+        self.page_count = 0
+
+
 class Syscall():
     # One instance for each unique syscall name per process
     def __init__(self):

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -34,7 +34,7 @@ class Process():
     def __init__(self):
         self.tid = None
         self.pid = None
-        self.comm = ""
+        self.comm = ''
         # indexed by fd
         self.fds = {}
         # indexed by filename
@@ -80,8 +80,8 @@ class Process():
 
     def track_chrono_fd(self, fd, filename, fdtype, timestamp):
         chrono_metadata = {}
-        chrono_metadata["filename"] = filename
-        chrono_metadata["fdtype"] = fdtype
+        chrono_metadata['filename'] = filename
+        chrono_metadata['fdtype'] = fdtype
 
         if fd not in self.chrono_fds:
             self.chrono_fds[fd] = OrderedDict()
@@ -89,7 +89,7 @@ class Process():
         else:
             chrono_fd = self.chrono_fds[fd]
             last_ts = next(reversed(chrono_fd))
-            if filename != chrono_fd[last_ts]["filename"]:
+            if filename != chrono_fd[last_ts]['filename']:
                 chrono_fd[timestamp] = chrono_metadata
 
 
@@ -113,7 +113,7 @@ class MemoryManagement():
 class Syscall():
     # One instance for each unique syscall name per process
     def __init__(self):
-        self.name = ""
+        self.name = ''
         self.count = 0
         # duration min/max
         self.min = None
@@ -133,8 +133,8 @@ class SyscallEvent():
 
 class Disk():
     def __init__(self):
-        self.name = ""
-        self.prettyname = ""
+        self.name = ''
+        self.prettyname = ''
         self.init_counts()
 
     def init_counts(self):
@@ -154,7 +154,7 @@ class Disk():
 
 class Iface():
     def __init__(self):
-        self.name = ""
+        self.name = ''
         self.init_counts()
 
     def init_counts(self):
@@ -175,7 +175,7 @@ class FDType():
 
 class FD():
     def __init__(self):
-        self.filename = ""
+        self.filename = ''
         self.fd = None
         # address family
         self.family = socket.AF_UNSPEC
@@ -206,16 +206,16 @@ class FD():
 
 class IRQ():
     # from include/linux/interrupt.h
-    soft_names = {0: "HI_SOFTIRQ",
-                  1: "TIMER_SOFTIRQ",
-                  2: "NET_TX_SOFTIRQ",
-                  3: "NET_RX_SOFTIRQ",
-                  4: "BLOCK_SOFTIRQ",
-                  5: "BLOCK_IOPOLL_SOFTIRQ",
-                  6: "TASKLET_SOFTIRQ",
-                  7: "SCHED_SOFTIRQ",
-                  8: "HRTIMER_SOFTIRQ",
-                  9: "RCU_SOFTIRQ"}
+    soft_names = {0: 'HI_SOFTIRQ',
+                  1: 'TIMER_SOFTIRQ',
+                  2: 'NET_TX_SOFTIRQ',
+                  3: 'NET_RX_SOFTIRQ',
+                  4: 'BLOCK_SOFTIRQ',
+                  5: 'BLOCK_IOPOLL_SOFTIRQ',
+                  6: 'TASKLET_SOFTIRQ',
+                  7: 'SCHED_SOFTIRQ',
+                  8: 'HRTIMER_SOFTIRQ',
+                  9: 'RCU_SOFTIRQ'}
 
     def __init__(self, id, start_ts=None):
         self.id = id
@@ -230,7 +230,7 @@ class HardIRQ(IRQ):
 
     @classmethod
     def new_from_irq_handler_entry(cls, event):
-        id = event["irq"]
+        id = event['irq']
         start_ts = event.timestamp
         return cls(id, start_ts)
 
@@ -242,19 +242,19 @@ class SoftIRQ(IRQ):
 
     @classmethod
     def new_from_softirq_raise(cls, event):
-        id = event["vec"]
+        id = event['vec']
         raise_ts = event.timestamp
         return cls(id, raise_ts)
 
     @classmethod
     def new_from_softirq_entry(cls, event):
-        id = event["vec"]
+        id = event['vec']
         start_ts = event.timestamp
         return cls(id, start_ts=start_ts)
 
 
 class IORequest():
-    # I/O "type"
+    # I/O 'type'
     IO_SYSCALL = 1
     IO_BLOCK = 2
     IO_NET = 3
@@ -336,42 +336,42 @@ class SyscallConsts():
     INET_FAMILIES = [socket.AF_INET, socket.AF_INET6]
     DISK_FAMILIES = [socket.AF_UNIX]
     # list nof syscalls that open a FD on disk (in the exit_syscall event)
-    DISK_OPEN_SYSCALLS = ["sys_open", "syscall_entry_open",
-                          "sys_openat", "syscall_entry_openat"]
+    DISK_OPEN_SYSCALLS = ['sys_open', 'syscall_entry_open',
+                          'sys_openat', 'syscall_entry_openat']
     # list of syscalls that open a FD on the network
     # (in the exit_syscall event)
-    NET_OPEN_SYSCALLS = ["sys_accept", "syscall_entry_accept",
-                         "sys_accept4", "syscall_entry_accept4",
-                         "sys_socket", "syscall_entry_socket"]
+    NET_OPEN_SYSCALLS = ['sys_accept', 'syscall_entry_accept',
+                         'sys_accept4', 'syscall_entry_accept4',
+                         'sys_socket', 'syscall_entry_socket']
     # list of syscalls that can duplicate a FD
-    DUP_OPEN_SYSCALLS = ["sys_fcntl", "syscall_entry_fcntl",
-                         "sys_dup2", "syscall_entry_dup2"]
-    SYNC_SYSCALLS = ["sys_sync", "syscall_entry_sync",
-                     "sys_sync_file_range", "syscall_entry_sync_file_range",
-                     "sys_fsync", "syscall_entry_fsync",
-                     "sys_fdatasync", "syscall_entry_fdatasync"]
+    DUP_OPEN_SYSCALLS = ['sys_fcntl', 'syscall_entry_fcntl',
+                         'sys_dup2', 'syscall_entry_dup2']
+    SYNC_SYSCALLS = ['sys_sync', 'syscall_entry_sync',
+                     'sys_sync_file_range', 'syscall_entry_sync_file_range',
+                     'sys_fsync', 'syscall_entry_fsync',
+                     'sys_fdatasync', 'syscall_entry_fdatasync']
     # merge the 3 open lists
     OPEN_SYSCALLS = DISK_OPEN_SYSCALLS + NET_OPEN_SYSCALLS + DUP_OPEN_SYSCALLS
-    # list of syscalls that close a FD (in the "fd =" field)
-    CLOSE_SYSCALLS = ["sys_close", "syscall_entry_close"]
+    # list of syscalls that close a FD (in the 'fd =' field)
+    CLOSE_SYSCALLS = ['sys_close', 'syscall_entry_close']
     # list of syscall that read on a FD, value in the exit_syscall following
-    READ_SYSCALLS = ["sys_read", "syscall_entry_read",
-                     "sys_recvmsg", "syscall_entry_recvmsg",
-                     "sys_recvfrom", "syscall_entry_recvfrom",
-                     "sys_splice", "syscall_entry_splice",
-                     "sys_readv", "syscall_entry_readv",
-                     "sys_sendfile64", "syscall_entry_sendfile64"]
+    READ_SYSCALLS = ['sys_read', 'syscall_entry_read',
+                     'sys_recvmsg', 'syscall_entry_recvmsg',
+                     'sys_recvfrom', 'syscall_entry_recvfrom',
+                     'sys_splice', 'syscall_entry_splice',
+                     'sys_readv', 'syscall_entry_readv',
+                     'sys_sendfile64', 'syscall_entry_sendfile64']
     # list of syscall that write on a FD, value in the exit_syscall following
-    WRITE_SYSCALLS = ["sys_write", "syscall_entry_write",
-                      "sys_sendmsg", "syscall_entry_sendmsg",
-                      "sys_sendto", "syscall_entry_sendto",
-                      "sys_writev", "syscall_entry_writev"]
+    WRITE_SYSCALLS = ['sys_write', 'syscall_entry_write',
+                      'sys_sendmsg', 'syscall_entry_sendmsg',
+                      'sys_sendto', 'syscall_entry_sendto',
+                      'sys_writev', 'syscall_entry_writev']
     # All I/O related syscalls
     IO_SYSCALLS = OPEN_SYSCALLS + CLOSE_SYSCALLS + READ_SYSCALLS + \
         WRITE_SYSCALLS + SYNC_SYSCALLS
     # generic names assigned to special FDs, don't try to match these in the
     # closed_fds dict
-    GENERIC_NAMES = ["unknown", "socket"]
+    GENERIC_NAMES = ['unknown', 'socket']
 
     def __init__():
         pass

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -99,9 +99,10 @@ class CPU():
         self.cpu_ns = 0
         self.current_tid = None
         self.current_hard_irq = None
-        # softirqs use a list because multiple ones can be raised before
-        # handling. They are appended chronologically.
-        self.current_softirqs = []
+        # softirqs use a dict because multiple ones can be raised before
+        # handling. They are indexed by vec, and each entry is a list,
+        # ordered chronologically
+        self.current_softirqs = {}
         self.start_task_ns = 0
         self.perf = {}
         self.wakeup_queue = []
@@ -229,7 +230,7 @@ class HardIRQ(IRQ):
 
 class SoftIRQ(IRQ):
     def __init__(self, id, cpu_id, raise_ts=None, start_ts=None):
-        super().__init__(id, cpu_id)
+        super().__init__(id, cpu_id, start_ts)
         self.raise_ts = raise_ts
 
     @classmethod

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -99,7 +99,9 @@ class CPU():
         self.cpu_ns = 0
         self.current_tid = None
         self.current_hard_irq = None
-        self.current_soft_irq = None
+        # softirqs use a list because multiple ones can be raised before
+        # handling. They are appended chronologically.
+        self.current_softirqs = []
         self.start_task_ns = 0
         self.perf = {}
         self.wakeup_queue = []
@@ -205,18 +207,6 @@ class FD():
 
 
 class IRQ():
-    # from include/linux/interrupt.h
-    soft_names = {0: 'HI_SOFTIRQ',
-                  1: 'TIMER_SOFTIRQ',
-                  2: 'NET_TX_SOFTIRQ',
-                  3: 'NET_RX_SOFTIRQ',
-                  4: 'BLOCK_SOFTIRQ',
-                  5: 'BLOCK_IOPOLL_SOFTIRQ',
-                  6: 'TASKLET_SOFTIRQ',
-                  7: 'SCHED_SOFTIRQ',
-                  8: 'HRTIMER_SOFTIRQ',
-                  9: 'RCU_SOFTIRQ'}
-
     def __init__(self, id, start_ts=None):
         self.id = id
         self.start_ts = start_ts

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -207,40 +207,44 @@ class FD():
 
 
 class IRQ():
-    def __init__(self, id, start_ts=None):
+    def __init__(self, id, cpu_id, start_ts=None):
         self.id = id
+        self.cpu_id = cpu_id
         self.start_ts = start_ts
         self.stop_ts = None
 
 
 class HardIRQ(IRQ):
-    def __init__(self, id, start_ts):
-        super().__init__(id, start_ts)
+    def __init__(self, id, cpu_id, start_ts):
+        super().__init__(id, cpu_id, start_ts)
         self.ret = None
 
     @classmethod
     def new_from_irq_handler_entry(cls, event):
         id = event['irq']
+        cpu_id = event['cpu_id']
         start_ts = event.timestamp
-        return cls(id, start_ts)
+        return cls(id, cpu_id, start_ts)
 
 
 class SoftIRQ(IRQ):
-    def __init__(self, id, raise_ts=None, start_ts=None):
-        super().__init__(id)
+    def __init__(self, id, cpu_id, raise_ts=None, start_ts=None):
+        super().__init__(id, cpu_id)
         self.raise_ts = raise_ts
 
     @classmethod
     def new_from_softirq_raise(cls, event):
         id = event['vec']
+        cpu_id = event['cpu_id']
         raise_ts = event.timestamp
-        return cls(id, raise_ts)
+        return cls(id, cpu_id, raise_ts)
 
     @classmethod
     def new_from_softirq_entry(cls, event):
         id = event['vec']
+        cpu_id = event['cpu_id']
         start_ts = event.timestamp
-        return cls(id, start_ts=start_ts)
+        return cls(id, cpu_id, start_ts=start_ts)
 
 
 class IORequest():

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -94,8 +94,8 @@ class Process():
 
 
 class CPU():
-    def __init__(self):
-        self.cpu_id = None
+    def __init__(self, cpu_id):
+        self.cpu_id = cpu_id
         self.cpu_ns = 0
         self.current_tid = None
         self.current_hard_irq = None

--- a/linuxautomaton/linuxautomaton/syscalls.py
+++ b/linuxautomaton/linuxautomaton/syscalls.py
@@ -34,7 +34,7 @@ class SyscallsStateProvider(sp.StateProvider):
         self.tids = state.tids
         self.syscalls = state.syscalls
         self.pending_syscalls = state.pending_syscalls
-        self.syscalls["total"] = 0
+        self.syscalls['total'] = 0
         cbs = {
             'syscall_entry': self._process_syscall_entry,
             'syscall_exit': self._process_syscall_exit,
@@ -68,16 +68,16 @@ class SyscallsStateProvider(sp.StateProvider):
         else:
             s = self.syscalls[name]
         s.count += 1
-        self.syscalls["total"] += 1
+        self.syscalls['total'] += 1
 
     def override_name(self, name, event):
-        if name in ["syscall_entry_epoll_ctl"]:
-            if event["op"] == 1:
-                name = "%s-ADD" % (name)
-            elif event["op"] == 2:
-                name = "%s-DEL" % (name)
-            elif event["op"] == 3:
-                name = "%s-MODE" % (name)
+        if name in ['syscall_entry_epoll_ctl']:
+            if event['op'] == 1:
+                name = '%s-ADD' % (name)
+            elif event['op'] == 2:
+                name = '%s-DEL' % (name)
+            elif event['op'] == 3:
+                name = '%s-MODE' % (name)
         return name
 
     def per_tid_syscall_entry(self, name, cpu_id, event):
@@ -98,59 +98,59 @@ class SyscallsStateProvider(sp.StateProvider):
             s = t.syscalls[name]
         s.count += 1
         current_syscall = t.current_syscall
-        current_syscall["name"] = name
-        current_syscall["start"] = event.timestamp
+        current_syscall['name'] = name
+        current_syscall['start'] = event.timestamp
         self.global_syscall_entry(name)
 
     def track_open(self, name, proc, event, cpu):
         self.tids[cpu.current_tid].current_syscall = {}
         current_syscall = self.tids[cpu.current_tid].current_syscall
         if name in sv.SyscallConsts.DISK_OPEN_SYSCALLS:
-            current_syscall["filename"] = event["filename"]
-            if event["flags"] & common.O_CLOEXEC == common.O_CLOEXEC:
-                current_syscall["cloexec"] = 1
-        elif name in ["sys_accept", "syscall_entry_accept",
-                      "sys_accept4", "syscall_entry_accept4"]:
-            if "family" in event.keys() and event["family"] == socket.AF_INET:
-                ipport = "%s:%d" % (common.get_v4_addr_str(event["v4addr"]),
-                                    event["sport"])
-                current_syscall["filename"] = ipport
+            current_syscall['filename'] = event['filename']
+            if event['flags'] & common.O_CLOEXEC == common.O_CLOEXEC:
+                current_syscall['cloexec'] = 1
+        elif name in ['sys_accept', 'syscall_entry_accept',
+                      'sys_accept4', 'syscall_entry_accept4']:
+            if 'family' in event.keys() and event['family'] == socket.AF_INET:
+                ipport = '%s:%d' % (common.get_v4_addr_str(event['v4addr']),
+                                    event['sport'])
+                current_syscall['filename'] = ipport
             else:
-                current_syscall["filename"] = "socket"
+                current_syscall['filename'] = 'socket'
         elif name in sv.SyscallConsts.NET_OPEN_SYSCALLS:
-            current_syscall["filename"] = "socket"
-        elif name in ["sys_dup2", "syscall_entry_dup2"]:
-            newfd = event["newfd"]
-            oldfd = event["oldfd"]
+            current_syscall['filename'] = 'socket'
+        elif name in ['sys_dup2', 'syscall_entry_dup2']:
+            newfd = event['newfd']
+            oldfd = event['oldfd']
             if newfd in proc.fds.keys():
                 self.close_fd(proc, newfd)
             if oldfd in proc.fds.keys():
-                current_syscall["filename"] = proc.fds[oldfd].filename
-                current_syscall["fdtype"] = proc.fds[oldfd].fdtype
+                current_syscall['filename'] = proc.fds[oldfd].filename
+                current_syscall['fdtype'] = proc.fds[oldfd].fdtype
             else:
-                current_syscall["filename"] = ""
-        elif name in ["sys_fcntl", "syscall_entry_fcntl"]:
+                current_syscall['filename'] = ''
+        elif name in ['sys_fcntl', 'syscall_entry_fcntl']:
             # F_DUPsv.FD
-            if event["cmd"] != 0:
+            if event['cmd'] != 0:
                 return
-            oldfd = event["fd"]
+            oldfd = event['fd']
             if oldfd in proc.fds.keys():
-                current_syscall["filename"] = proc.fds[oldfd].filename
-                current_syscall["fdtype"] = proc.fds[oldfd].fdtype
+                current_syscall['filename'] = proc.fds[oldfd].filename
+                current_syscall['fdtype'] = proc.fds[oldfd].fdtype
             else:
-                current_syscall["filename"] = ""
+                current_syscall['filename'] = ''
 
         if name in sv.SyscallConsts.NET_OPEN_SYSCALLS and \
-                "family" in event.keys():
-            family = event["family"]
-            current_syscall["family"] = family
+                'family' in event.keys():
+            family = event['family']
+            current_syscall['family'] = family
         else:
             family = socket.AF_UNSPEC
-            current_syscall["family"] = family
+            current_syscall['family'] = family
 
-        current_syscall["name"] = name
-        current_syscall["start"] = event.timestamp
-        current_syscall["fdtype"] = self.get_fd_type(name, family)
+        current_syscall['name'] = name
+        current_syscall['start'] = event.timestamp
+        current_syscall['fdtype'] = self.get_fd_type(name, family)
 
     def close_fd(self, proc, fd):
         filename = proc.fds[fd].filename
@@ -169,34 +169,34 @@ class SyscallsStateProvider(sp.StateProvider):
         proc.fds.pop(fd, None)
 
     def track_close(self, name, proc, event, cpu):
-        fd = event["fd"]
+        fd = event['fd']
         if fd not in proc.fds.keys():
             return
 
         tid = self.tids[cpu.current_tid]
         tid.current_syscall = {}
         current_syscall = tid.current_syscall
-        current_syscall["filename"] = proc.fds[fd].filename
-        current_syscall["name"] = name
-        current_syscall["start"] = event.timestamp
+        current_syscall['filename'] = proc.fds[fd].filename
+        current_syscall['name'] = name
+        current_syscall['start'] = event.timestamp
 
         self.close_fd(proc, fd)
 
     def _fix_context_pid(self, event, t):
         for context in event.field_list_with_scope(
                 CTFScope.STREAM_EVENT_CONTEXT):
-            if context != "pid":
+            if context != 'pid':
                 continue
-            # make sure the "pid" field is not also in the event
+            # make sure the 'pid' field is not also in the event
             # payload, otherwise we might clash
             for context in event.field_list_with_scope(
                     CTFScope.EVENT_FIELDS):
-                if context == "pid":
+                if context == 'pid':
                     return
             if t.pid is None:
-                t.pid == event["pid"]
-                if event["pid"] != t.tid:
-                    t.pid = event["pid"]
+                t.pid == event['pid']
+                if event['pid'] != t.tid:
+                    t.pid = event['pid']
                     p = sv.Process()
                     p.tid = t.pid
                     p.pid = t.pid
@@ -221,20 +221,20 @@ class SyscallsStateProvider(sp.StateProvider):
         elif name in sv.SyscallConsts.CLOSE_SYSCALLS:
             self.track_close(name, t, event, c)
         # when a connect occurs, no new sv.FD is returned, but we can fix
-        # the "filename" if we have the destination info
-        elif name in ["sys_connect", "syscall_entry_connect"] \
-                and "family" in event.keys():
-            if event["family"] == socket.AF_INET:
-                fd = self.get_fd(t, event["fd"], event)
-                ipport = "%s:%d" % (common.get_v4_addr_str(event["v4addr"]),
-                                    event["dport"])
+        # the 'filename' if we have the destination info
+        elif name in ['sys_connect', 'syscall_entry_connect'] \
+                and 'family' in event.keys():
+            if event['family'] == socket.AF_INET:
+                fd = self.get_fd(t, event['fd'], event)
+                ipport = '%s:%d' % (common.get_v4_addr_str(event['v4addr']),
+                                    event['dport'])
                 fd.filename = ipport
 
     def get_fd(self, proc, fd, event):
         if fd not in proc.fds.keys():
             f = sv.FD()
             f.fd = fd
-            f.filename = "unknown (origin not found)"
+            f.filename = 'unknown (origin not found)'
             proc.fds[fd] = f
         else:
             f = proc.fds[fd]
@@ -256,13 +256,13 @@ class SyscallsStateProvider(sp.StateProvider):
         if t.pid is not None and t.tid != t.pid:
             t = self.tids[t.pid]
         current_syscall = self.tids[c.current_tid].current_syscall
-        current_syscall["name"] = name
-        current_syscall["start"] = event.timestamp
-        if name not in ["sys_sync", "syscall_entry_sync"]:
-            fd = event["fd"]
+        current_syscall['name'] = name
+        current_syscall['start'] = event.timestamp
+        if name not in ['sys_sync', 'syscall_entry_sync']:
+            fd = event['fd']
             f = self.get_fd(t, fd, event)
-            current_syscall["fd"] = f
-            current_syscall["filename"] = f.filename
+            current_syscall['fd'] = f
+            current_syscall['filename'] = f.filename
 
     def track_read_write(self, name, event, cpu_id):
         # we don't know which process is currently on this CPU
@@ -277,52 +277,52 @@ class SyscallsStateProvider(sp.StateProvider):
         if t.pid is not None and t.tid != t.pid:
             t = self.tids[t.pid]
         current_syscall = self.tids[c.current_tid].current_syscall
-        current_syscall["name"] = name
-        current_syscall["start"] = event.timestamp
-        if name in ["sys_splice", "syscall_entry_splice"]:
-            current_syscall["fd_in"] = self.get_fd(t, event["fd_in"], event)
-            current_syscall["fd_out"] = self.get_fd(t, event["fd_out"], event)
-            current_syscall["count"] = event["len"]
-            current_syscall["filename"] = current_syscall["fd_in"].filename
+        current_syscall['name'] = name
+        current_syscall['start'] = event.timestamp
+        if name in ['sys_splice', 'syscall_entry_splice']:
+            current_syscall['fd_in'] = self.get_fd(t, event['fd_in'], event)
+            current_syscall['fd_out'] = self.get_fd(t, event['fd_out'], event)
+            current_syscall['count'] = event['len']
+            current_syscall['filename'] = current_syscall['fd_in'].filename
             return
-        elif name in ["sys_sendfile64", "syscall_entry_sendfile64"]:
-            current_syscall["fd_in"] = self.get_fd(t, event["in_fd"], event)
-            current_syscall["fd_out"] = self.get_fd(t, event["out_fd"], event)
-            current_syscall["count"] = event["count"]
-            current_syscall["filename"] = current_syscall["fd_in"].filename
+        elif name in ['sys_sendfile64', 'syscall_entry_sendfile64']:
+            current_syscall['fd_in'] = self.get_fd(t, event['in_fd'], event)
+            current_syscall['fd_out'] = self.get_fd(t, event['out_fd'], event)
+            current_syscall['count'] = event['count']
+            current_syscall['filename'] = current_syscall['fd_in'].filename
             return
-        fd = event["fd"]
+        fd = event['fd']
         f = self.get_fd(t, fd, event)
-        current_syscall["fd"] = f
-        if name in ["sys_writev", "syscall_entry_writev",
-                    "sys_readv", "syscall_entry_readv"]:
-            current_syscall["count"] = event["vlen"]
-        elif name in ["sys_recvfrom", "syscall_entry_recvfrom"]:
-            current_syscall["count"] = event["size"]
-        elif name in ["sys_recvmsg", "syscall_entry_recvmsg",
-                      "sys_sendmsg", "syscall_entry_sendmsg"]:
-            current_syscall["count"] = ""
-        elif name in ["sys_sendto", "syscall_entry_sendto"]:
-            current_syscall["count"] = event["len"]
+        current_syscall['fd'] = f
+        if name in ['sys_writev', 'syscall_entry_writev',
+                    'sys_readv', 'syscall_entry_readv']:
+            current_syscall['count'] = event['vlen']
+        elif name in ['sys_recvfrom', 'syscall_entry_recvfrom']:
+            current_syscall['count'] = event['size']
+        elif name in ['sys_recvmsg', 'syscall_entry_recvmsg',
+                      'sys_sendmsg', 'syscall_entry_sendmsg']:
+            current_syscall['count'] = ''
+        elif name in ['sys_sendto', 'syscall_entry_sendto']:
+            current_syscall['count'] = event['len']
         else:
             try:
-                current_syscall["count"] = event["count"]
+                current_syscall['count'] = event['count']
             except:
-                print("Missing count argument for syscall",
-                      current_syscall["name"])
-                current_syscall["count"] = 0
+                print('Missing count argument for syscall',
+                      current_syscall['name'])
+                current_syscall['count'] = 0
 
-        current_syscall["filename"] = f.filename
+        current_syscall['filename'] = f.filename
 
     def add_tid_fd(self, event, cpu):
-        ret = event["ret"]
+        ret = event['ret']
         t = self.tids[cpu.current_tid]
         # if it's a thread, we want the parent
         if t.pid is not None and t.tid != t.pid:
             t = self.tids[t.pid]
         current_syscall = self.tids[cpu.current_tid].current_syscall
 
-        name = current_syscall["filename"]
+        name = current_syscall['filename']
         if name not in sv.SyscallConsts.GENERIC_NAMES \
            and name in t.closed_fds.keys():
             fd = t.closed_fds[name]
@@ -330,8 +330,8 @@ class SyscallsStateProvider(sp.StateProvider):
         else:
             fd = sv.FD()
             fd.filename = name
-            if current_syscall["name"] in sv.SyscallConsts.NET_OPEN_SYSCALLS:
-                fd.family = current_syscall["family"]
+            if current_syscall['name'] in sv.SyscallConsts.NET_OPEN_SYSCALLS:
+                fd.family = current_syscall['family']
                 if fd.family in sv.SyscallConsts.INET_FAMILIES:
                     fd.fdtype = sv.FDType.net
             fd.open = 1
@@ -339,7 +339,7 @@ class SyscallsStateProvider(sp.StateProvider):
             fd.fd = ret
         else:
             return
-        if "cloexec" in current_syscall.keys():
+        if 'cloexec' in current_syscall.keys():
             fd.cloexec = 1
         t.fds[fd.fd] = fd
 
@@ -384,51 +384,51 @@ class SyscallsStateProvider(sp.StateProvider):
         if proc.pid is not None and proc.tid != proc.pid:
             proc = self.tids[proc.pid]
         current_syscall = self.tids[cpu.current_tid].current_syscall
-        if name in ["sys_splice", "syscall_entry_splice",
-                    "sys_sendfile64", "syscall_entry_sendfile64"]:
-            self.read_append(current_syscall["fd_in"], proc, ret,
-                             current_syscall["iorequest"])
-            self.write_append(current_syscall["fd_out"], proc, ret,
-                              current_syscall["iorequest"])
+        if name in ['sys_splice', 'syscall_entry_splice',
+                    'sys_sendfile64', 'syscall_entry_sendfile64']:
+            self.read_append(current_syscall['fd_in'], proc, ret,
+                             current_syscall['iorequest'])
+            self.write_append(current_syscall['fd_out'], proc, ret,
+                              current_syscall['iorequest'])
         elif name in sv.SyscallConsts.READ_SYSCALLS:
             if ret > 0:
-                self.read_append(current_syscall["fd"], proc, ret,
-                                 current_syscall["iorequest"])
+                self.read_append(current_syscall['fd'], proc, ret,
+                                 current_syscall['iorequest'])
         elif name in sv.SyscallConsts.WRITE_SYSCALLS:
             if ret > 0:
-                self.write_append(current_syscall["fd"], proc, ret,
-                                  current_syscall["iorequest"])
+                self.write_append(current_syscall['fd'], proc, ret,
+                                  current_syscall['iorequest'])
 
     def track_rw_latency(self, name, ret, c, ts, event):
         current_syscall = self.tids[c.current_tid].current_syscall
-        rq = current_syscall["iorequest"]
-        rq.duration = (event.timestamp - current_syscall["start"])
-        rq.begin = current_syscall["start"]
+        rq = current_syscall['iorequest']
+        rq.duration = (event.timestamp - current_syscall['start'])
+        rq.begin = current_syscall['start']
         rq.end = event.timestamp
         rq.proc = self.tids[c.current_tid]
-        if "fd" in current_syscall.keys():
-            rq.fd = current_syscall["fd"]
-            r = current_syscall["fd"].iorequests
-            r.append(current_syscall["iorequest"])
-        elif "fd_in" in current_syscall.keys():
-            rq.fd = current_syscall["fd_in"]
+        if 'fd' in current_syscall.keys():
+            rq.fd = current_syscall['fd']
+            r = current_syscall['fd'].iorequests
+            r.append(current_syscall['iorequest'])
+        elif 'fd_in' in current_syscall.keys():
+            rq.fd = current_syscall['fd_in']
         # pages written during the latency
-        if "pages_written" in current_syscall.keys():
-            rq.page_written = current_syscall["pages_written"]
+        if 'pages_written' in current_syscall.keys():
+            rq.page_written = current_syscall['pages_written']
         # dirty buffers during the latency
-        if "dirty" in current_syscall.keys():
-            rq.dirty = current_syscall["dirty"]
+        if 'dirty' in current_syscall.keys():
+            rq.dirty = current_syscall['dirty']
         # allocated pages during the latency
-        if "pages_allocated" in current_syscall.keys():
-            rq.page_alloc = current_syscall["pages_allocated"]
+        if 'pages_allocated' in current_syscall.keys():
+            rq.page_alloc = current_syscall['pages_allocated']
         # wakeup_kswapd during the latency
-        if "page_free" in current_syscall.keys():
-            rq.page_free = current_syscall["page_free"]
-        if "wakeup_kswapd" in current_syscall.keys():
+        if 'page_free' in current_syscall.keys():
+            rq.page_free = current_syscall['page_free']
+        if 'wakeup_kswapd' in current_syscall.keys():
             rq.woke_kswapd = True
         if name in sv.SyscallConsts.SYNC_SYSCALLS:
-            if "pages_cleared" in current_syscall.keys():
-                rq.page_cleared = len(current_syscall["pages_cleared"])
+            if 'pages_cleared' in current_syscall.keys():
+                rq.page_cleared = len(current_syscall['pages_cleared'])
 
     def _per_tid_syscall_exit(self, name, ret, event, c):
         t = self.tids[c.current_tid]
@@ -436,7 +436,7 @@ class SyscallsStateProvider(sp.StateProvider):
             return
         s = sv.SyscallEvent()
         s.ret = ret
-        s.entry_ts = t.current_syscall["start"]
+        s.entry_ts = t.current_syscall['start']
         s.exit_ts = event.timestamp
         s.duration = s.exit_ts - s.entry_ts
         t_syscall = t.syscalls[name]
@@ -449,7 +449,7 @@ class SyscallsStateProvider(sp.StateProvider):
 
     def _process_syscall_entry(self, event):
         name = event.name
-        cpu_id = event["cpu_id"]
+        cpu_id = event['cpu_id']
         self.per_tid_syscall_entry(name, cpu_id, event)
         self.track_fds(name, event, cpu_id)
         if name in sv.SyscallConsts.READ_SYSCALLS or \
@@ -459,7 +459,7 @@ class SyscallsStateProvider(sp.StateProvider):
             self.track_sync(name, event, cpu_id)
 
     def _process_syscall_exit(self, event):
-        cpu_id = event["cpu_id"]
+        cpu_id = event['cpu_id']
         if cpu_id not in self.cpus:
             return
         c = self.cpus[cpu_id]
@@ -468,25 +468,25 @@ class SyscallsStateProvider(sp.StateProvider):
         current_syscall = self.tids[c.current_tid].current_syscall
         if not current_syscall:
             return
-        name = current_syscall["name"]
-        ret = event["ret"]
+        name = current_syscall['name']
+        ret = event['ret']
         self._per_tid_syscall_exit(name, ret, event, c)
 
         if name not in sv.SyscallConsts.IO_SYSCALLS:
             return
 
-        current_syscall["iorequest"] = sv.IORequest()
-        current_syscall["iorequest"].iotype = sv.IORequest.IO_SYSCALL
-        current_syscall["iorequest"].name = name
+        current_syscall['iorequest'] = sv.IORequest()
+        current_syscall['iorequest'].iotype = sv.IORequest.IO_SYSCALL
+        current_syscall['iorequest'].name = name
         if name in sv.SyscallConsts.OPEN_SYSCALLS:
             self.add_tid_fd(event, c)
             if ret < 0:
                 return
             t = self.tids[c.current_tid]
-            current_syscall["fd"] = self.get_fd(t, ret, event)
-            current_syscall["count"] = 0
-            current_syscall["fd"].fdtype = current_syscall["fdtype"]
-            current_syscall["iorequest"].operation = sv.IORequest.OP_OPEN
+            current_syscall['fd'] = self.get_fd(t, ret, event)
+            current_syscall['count'] = 0
+            current_syscall['fd'].fdtype = current_syscall['fdtype']
+            current_syscall['iorequest'].operation = sv.IORequest.OP_OPEN
             self.track_rw_latency(name, ret, c,
                                   event.timestamp, event)
         elif name in sv.SyscallConsts.READ_SYSCALLS or \
@@ -494,11 +494,11 @@ class SyscallsStateProvider(sp.StateProvider):
             self.track_read_write_return(name, ret, c)
             self.track_rw_latency(name, ret, c, event.timestamp, event)
         elif name in sv.SyscallConsts.SYNC_SYSCALLS:
-            current_syscall["iorequest"].operation = sv.IORequest.OP_SYNC
+            current_syscall['iorequest'].operation = sv.IORequest.OP_SYNC
             self.track_rw_latency(name, ret, c, event.timestamp, event)
-            if name in ["sys_sync", "syscall_entry_sync"]:
+            if name in ['sys_sync', 'syscall_entry_sync']:
                 t = self.tids[c.current_tid]
-                t.iorequests.append(current_syscall["iorequest"])
+                t.iorequests.append(current_syscall['iorequest'])
         self.tids[c.current_tid].current_syscall = {}
         if self.tids[c.current_tid] in self.pending_syscalls:
             self.pending_syscalls.remove(self.tids[c.current_tid])
@@ -511,11 +511,11 @@ class SyscallsStateProvider(sp.StateProvider):
             current_syscall = self.tids[c.current_tid].current_syscall
             if not current_syscall:
                 continue
-            current_syscall["pages_written"] = event["pages"]
+            current_syscall['pages_written'] = event['pages']
 
     def _process_mm_vmscan_wakeup_kswapd(self, event):
         """mm_vmscan_wakeup_kswapd"""
-        cpu_id = event["cpu_id"]
+        cpu_id = event['cpu_id']
         if cpu_id not in self.cpus:
             return
         c = self.cpus[cpu_id]
@@ -524,7 +524,7 @@ class SyscallsStateProvider(sp.StateProvider):
         current_syscall = self.tids[c.current_tid].current_syscall
         if current_syscall:
             return
-        current_syscall["wakeup_kswapd"] = 1
+        current_syscall['wakeup_kswapd'] = 1
 
     def _process_mm_page_free(self, event):
         """mm_page_free"""
@@ -535,13 +535,13 @@ class SyscallsStateProvider(sp.StateProvider):
             # if the current process is kswapd0, we need to
             # attribute the page freed to the process that
             # woke it up.
-            if p.comm == "kswapd0" and p.prev_tid > 0:
+            if p.comm == 'kswapd0' and p.prev_tid > 0:
                 p = self.tids[p.prev_tid]
             current_syscall = p.current_syscall
             if current_syscall:
                 continue
-            if "wakeup_kswapd" in current_syscall.keys():
-                if "page_free" in current_syscall.keys():
-                    current_syscall["page_free"] += 1
+            if 'wakeup_kswapd' in current_syscall.keys():
+                if 'page_free' in current_syscall.keys():
+                    current_syscall['page_free'] += 1
                 else:
-                    current_syscall["page_free"] = 1
+                    current_syscall['page_free'] = 1

--- a/linuxautomaton/linuxautomaton/syscalls.py
+++ b/linuxautomaton/linuxautomaton/syscalls.py
@@ -432,7 +432,7 @@ class SyscallsStateProvider(sp.StateProvider):
 
     def _per_tid_syscall_exit(self, name, ret, event, c):
         t = self.tids[c.current_tid]
-        if not name in t.syscalls:
+        if name not in t.syscalls:
             return
         s = sv.SyscallEvent()
         s.ret = ret

--- a/linuxautomaton/linuxautomaton/syscalls.py
+++ b/linuxautomaton/linuxautomaton/syscalls.py
@@ -85,7 +85,7 @@ class SyscallsStateProvider(sp.StateProvider):
         if cpu_id not in self.cpus:
             return
         c = self.cpus[cpu_id]
-        if c.current_tid == -1:
+        if c.current_tid is None:
             return
         t = self.tids[c.current_tid]
         t.total_syscalls += 1
@@ -193,7 +193,7 @@ class SyscallsStateProvider(sp.StateProvider):
                     CTFScope.EVENT_FIELDS):
                 if context == "pid":
                     return
-            if t.pid == -1:
+            if t.pid is None:
                 t.pid == event["pid"]
                 if event["pid"] != t.tid:
                     t.pid = event["pid"]
@@ -208,13 +208,13 @@ class SyscallsStateProvider(sp.StateProvider):
         if cpu_id not in self.cpus:
             return
         c = self.cpus[cpu_id]
-        if c.current_tid == -1:
+        if c.current_tid is None:
             return
         t = self.tids[c.current_tid]
         # check if we can fix the pid from a context
         self._fix_context_pid(event, t)
         # if it's a thread, we want the parent
-        if t.pid != -1 and t.tid != t.pid:
+        if t.pid is not None and t.tid != t.pid:
             t = self.tids[t.pid]
         if name in sv.SyscallConsts.OPEN_SYSCALLS:
             self.track_open(name, t, event, c)
@@ -248,12 +248,12 @@ class SyscallsStateProvider(sp.StateProvider):
         if cpu_id not in self.cpus:
             return
         c = self.cpus[cpu_id]
-        if c.current_tid == -1:
+        if c.current_tid is None:
             return
         t = self.tids[c.current_tid]
         self.pending_syscalls.append(t)
         # if it's a thread, we want the parent
-        if t.pid != -1 and t.tid != t.pid:
+        if t.pid is not None and t.tid != t.pid:
             t = self.tids[t.pid]
         current_syscall = self.tids[c.current_tid].current_syscall
         current_syscall["name"] = name
@@ -269,12 +269,12 @@ class SyscallsStateProvider(sp.StateProvider):
         if cpu_id not in self.cpus:
             return
         c = self.cpus[cpu_id]
-        if c.current_tid == -1:
+        if c.current_tid is None:
             return
         t = self.tids[c.current_tid]
         self.pending_syscalls.append(t)
         # if it's a thread, we want the parent
-        if t.pid != -1 and t.tid != t.pid:
+        if t.pid is not None and t.tid != t.pid:
             t = self.tids[t.pid]
         current_syscall = self.tids[c.current_tid].current_syscall
         current_syscall["name"] = name
@@ -318,7 +318,7 @@ class SyscallsStateProvider(sp.StateProvider):
         ret = event["ret"]
         t = self.tids[cpu.current_tid]
         # if it's a thread, we want the parent
-        if t.pid != -1 and t.tid != t.pid:
+        if t.pid is not None and t.tid != t.pid:
             t = self.tids[t.pid]
         current_syscall = self.tids[cpu.current_tid].current_syscall
 
@@ -381,7 +381,7 @@ class SyscallsStateProvider(sp.StateProvider):
             return
         proc = self.tids[cpu.current_tid]
         # if it's a thread, we want the parent
-        if proc.pid != -1 and proc.tid != proc.pid:
+        if proc.pid is not None and proc.tid != proc.pid:
             proc = self.tids[proc.pid]
         current_syscall = self.tids[cpu.current_tid].current_syscall
         if name in ["sys_splice", "syscall_entry_splice",
@@ -463,7 +463,7 @@ class SyscallsStateProvider(sp.StateProvider):
         if cpu_id not in self.cpus:
             return
         c = self.cpus[cpu_id]
-        if c.current_tid == -1:
+        if c.current_tid is None:
             return
         current_syscall = self.tids[c.current_tid].current_syscall
         if len(current_syscall.keys()) == 0:
@@ -506,7 +506,7 @@ class SyscallsStateProvider(sp.StateProvider):
     def _process_writeback_pages_written(self, event):
         """writeback_pages_written"""
         for c in self.cpus.values():
-            if c.current_tid <= 0:
+            if c.current_tid is None:
                 continue
             current_syscall = self.tids[c.current_tid].current_syscall
             if len(current_syscall.keys()) == 0:
@@ -519,7 +519,7 @@ class SyscallsStateProvider(sp.StateProvider):
         if cpu_id not in self.cpus:
             return
         c = self.cpus[cpu_id]
-        if c.current_tid == -1:
+        if c.current_tid is None:
             return
         current_syscall = self.tids[c.current_tid].current_syscall
         if len(current_syscall.keys()) == 0:
@@ -529,7 +529,7 @@ class SyscallsStateProvider(sp.StateProvider):
     def _process_mm_page_free(self, event):
         """mm_page_free"""
         for c in self.cpus.values():
-            if c.current_tid <= 0:
+            if c.current_tid is None:
                 continue
             p = self.tids[c.current_tid]
             # if the current process is kswapd0, we need to

--- a/linuxautomaton/linuxautomaton/syscalls.py
+++ b/linuxautomaton/linuxautomaton/syscalls.py
@@ -35,7 +35,6 @@ class SyscallsStateProvider(sp.StateProvider):
         self.syscalls = state.syscalls
         self.pending_syscalls = state.pending_syscalls
         self.syscalls["total"] = 0
-        self.dirty_pages = state.dirty_pages
         cbs = {
             'syscall_entry': self._process_syscall_entry,
             'syscall_exit': self._process_syscall_exit,
@@ -419,9 +418,9 @@ class SyscallsStateProvider(sp.StateProvider):
         # dirty buffers during the latency
         if "dirty" in current_syscall.keys():
             rq.dirty = current_syscall["dirty"]
-        # alloc pages during the latency
-        if "alloc" in current_syscall.keys():
-            rq.page_alloc = current_syscall["alloc"]
+        # allocated pages during the latency
+        if "pages_allocated" in current_syscall.keys():
+            rq.page_alloc = current_syscall["pages_allocated"]
         # wakeup_kswapd during the latency
         if "page_free" in current_syscall.keys():
             rq.page_free = current_syscall["page_free"]

--- a/linuxautomaton/linuxautomaton/syscalls.py
+++ b/linuxautomaton/linuxautomaton/syscalls.py
@@ -466,7 +466,7 @@ class SyscallsStateProvider(sp.StateProvider):
         if c.current_tid is None:
             return
         current_syscall = self.tids[c.current_tid].current_syscall
-        if len(current_syscall.keys()) == 0:
+        if not current_syscall:
             return
         name = current_syscall["name"]
         ret = event["ret"]
@@ -509,7 +509,7 @@ class SyscallsStateProvider(sp.StateProvider):
             if c.current_tid is None:
                 continue
             current_syscall = self.tids[c.current_tid].current_syscall
-            if len(current_syscall.keys()) == 0:
+            if not current_syscall:
                 continue
             current_syscall["pages_written"] = event["pages"]
 
@@ -522,7 +522,7 @@ class SyscallsStateProvider(sp.StateProvider):
         if c.current_tid is None:
             return
         current_syscall = self.tids[c.current_tid].current_syscall
-        if len(current_syscall.keys()) == 0:
+        if current_syscall:
             return
         current_syscall["wakeup_kswapd"] = 1
 
@@ -538,7 +538,7 @@ class SyscallsStateProvider(sp.StateProvider):
             if p.comm == "kswapd0" and p.prev_tid > 0:
                 p = self.tids[p.prev_tid]
             current_syscall = p.current_syscall
-            if len(current_syscall.keys()) == 0:
+            if current_syscall:
                 continue
             if "wakeup_kswapd" in current_syscall.keys():
                 if "page_free" in current_syscall.keys():

--- a/lttnganalyses/lttnganalyses/analysis.py
+++ b/lttnganalyses/lttnganalyses/analysis.py
@@ -26,3 +26,19 @@
 class Analysis:
     def process_event(self, ev):
         raise NotImplementedError()
+
+    def _register_cbs(self, cbs):
+        self._cbs = cbs
+
+    def _process_event_cb(self, ev):
+        name = ev.name
+
+        if name in self._cbs:
+            self._cbs[name](ev)
+        elif "syscall_entry" in self._cbs and \
+           (name.startswith("sys_") or name.startswith("syscall_entry_")):
+            self._cbs["syscall_entry"](ev)
+        elif "syscall_exit" in self._cbs and \
+                (name.startswith("exit_syscall") or
+                 name.startswith("syscall_exit_")):
+            self._cbs["syscall_exit"](ev)

--- a/lttnganalyses/lttnganalyses/analysis.py
+++ b/lttnganalyses/lttnganalyses/analysis.py
@@ -35,10 +35,10 @@ class Analysis:
 
         if name in self._cbs:
             self._cbs[name](ev)
-        elif "syscall_entry" in self._cbs and \
-           (name.startswith("sys_") or name.startswith("syscall_entry_")):
-            self._cbs["syscall_entry"](ev)
-        elif "syscall_exit" in self._cbs and \
-                (name.startswith("exit_syscall") or
-                 name.startswith("syscall_exit_")):
-            self._cbs["syscall_exit"](ev)
+        elif 'syscall_entry' in self._cbs and \
+        (name.startswith('sys_') or name.startswith('syscall_entry_')):
+            self._cbs['syscall_entry'](ev)
+        elif 'syscall_exit' in self._cbs and \
+                (name.startswith('exit_syscall') or
+                 name.startswith('syscall_exit_')):
+            self._cbs['syscall_exit'](ev)

--- a/lttnganalyses/lttnganalyses/analysis.py
+++ b/lttnganalyses/lttnganalyses/analysis.py
@@ -36,7 +36,7 @@ class Analysis:
         if name in self._cbs:
             self._cbs[name](ev)
         elif 'syscall_entry' in self._cbs and \
-        (name.startswith('sys_') or name.startswith('syscall_entry_')):
+             (name.startswith('sys_') or name.startswith('syscall_entry_')):
             self._cbs['syscall_entry'](ev)
         elif 'syscall_exit' in self._cbs and \
                 (name.startswith('exit_syscall') or

--- a/lttnganalyses/lttnganalyses/irq.py
+++ b/lttnganalyses/lttnganalyses/irq.py
@@ -2,7 +2,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
+# Copyright (C) 2015 - Antoine Busque <abusque@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lttnganalyses/lttnganalyses/irq.py
+++ b/lttnganalyses/lttnganalyses/irq.py
@@ -27,7 +27,19 @@ from .analysis import Analysis
 
 class IrqAnalysis(Analysis):
     def __init__(self, state):
+        notification_cbs = {
+            'irq_handler_exit': self._process_irq_handler_exit,
+            'softirq_exit': self._process_softirq_exit
+        }
+
         self._state = state
+        self._state._register_notification_cbs(notification_cbs)
 
     def process_event(self, ev):
+        pass
+
+    def _process_irq_handler_exit(self, **kwargs):
+        pass
+
+    def _process_softirq_exit(self, **kwargs):
         pass

--- a/lttnganalyses/lttnganalyses/irq.py
+++ b/lttnganalyses/lttnganalyses/irq.py
@@ -98,7 +98,11 @@ class IrqStats():
         self.min_duration = None
         self.max_duration = None
         self.total_duration = 0
-        self.count = 0
+        self.irq_list = []
+
+    @property
+    def count(self):
+        return len(self.irq_list)
 
     def update_stats(self, irq):
         duration = irq.stop_ts - irq.start_ts
@@ -110,7 +114,7 @@ class IrqStats():
             self.max_duration = duration
 
         self.total_duration += duration
-        self.count += 1
+        self.irq_list.append(irq)
 
 
 class HardIrqStats(IrqStats):
@@ -136,6 +140,7 @@ class SoftIrqStats(IrqStats):
         self.min_raise_latency = None
         self.max_raise_latency = None
         self.total_raise_latency = 0
+        self.raise_count = 0
 
     def update_stats(self, irq):
         super().update_stats(irq)
@@ -153,3 +158,4 @@ class SoftIrqStats(IrqStats):
             self.max_raise_latency = raise_latency
 
         self.total_raise_latency += raise_latency
+        self.raise_count += 1

--- a/lttnganalyses/lttnganalyses/irq.py
+++ b/lttnganalyses/lttnganalyses/irq.py
@@ -116,6 +116,12 @@ class IrqStats():
         self.total_duration += duration
         self.irq_list.append(irq)
 
+    def reset(self):
+        self.min_duration = None
+        self.max_duration = None
+        self.total_duration = 0
+        self.irq_list = []
+
 
 class HardIrqStats(IrqStats):
     def __init__(self, name='unknown'):
@@ -159,3 +165,10 @@ class SoftIrqStats(IrqStats):
 
         self.total_raise_latency += raise_latency
         self.raise_count += 1
+
+    def reset(self):
+        super().reset()
+        self.min_raise_latency = None
+        self.max_raise_latency = None
+        self.total_raise_latency = 0
+        self.raise_count = 0

--- a/lttnganalyses/lttnganalyses/irq.py
+++ b/lttnganalyses/lttnganalyses/irq.py
@@ -156,11 +156,11 @@ class SoftIrqStats(IrqStats):
 
         raise_latency = irq.start_ts - irq.raise_ts
         if self.min_raise_latency is None or \
-        raise_latency < self.min_raise_latency:
+           raise_latency < self.min_raise_latency:
             self.min_raise_latency = raise_latency
 
         if self.max_raise_latency is None or \
-        raise_latency > self.max_raise_latency:
+           raise_latency > self.max_raise_latency:
             self.max_raise_latency = raise_latency
 
         self.total_raise_latency += raise_latency

--- a/lttnganalysescli/lttnganalysescli/command.py
+++ b/lttnganalysescli/lttnganalysescli/command.py
@@ -60,9 +60,9 @@ class Command:
 
     def _open_trace(self):
         traces = TraceCollection()
-        handle = traces.add_traces_recursive(self._arg_path, "ctf")
+        handle = traces.add_traces_recursive(self._arg_path, 'ctf')
         if handle == {}:
-            self._gen_error("Failed to open " + self._arg_path, -1)
+            self._gen_error('Failed to open ' + self._arg_path, -1)
         self._handle = handle
         self._traces = traces
         common.process_date_args(self)
@@ -74,13 +74,13 @@ class Command:
             self._traces.remove_trace(h)
 
     def _check_lost_events(self):
-        print("Checking the trace for lost events...")
+        print('Checking the trace for lost events...')
         try:
-            subprocess.check_output("babeltrace %s" % self._arg_path,
+            subprocess.check_output('babeltrace %s' % self._arg_path,
                                     shell=True)
         except subprocess.CalledProcessError:
-            print("Error running babeltrace on the trace, cannot verify if "
-                  "events were lost during the trace recording")
+            print('Error running babeltrace on the trace, cannot verify if '
+                  'events were lost during the trace recording')
 
     def _run_analysis(self, reset_cb, refresh_cb, break_cb=None):
         self.trace_start_ts = 0
@@ -162,11 +162,11 @@ class Command:
         if self._enable_proc_filter_args:
             self._arg_proc_list = None
             if args.procname:
-                self._arg_proc_list = args.procname.split(",")
+                self._arg_proc_list = args.procname.split(',')
 
             self._arg_pid_list = None
             if args.pid:
-                self._arg_pid_list = args.pid.split(",")
+                self._arg_pid_list = args.pid.split(',')
 
         if self._enable_max_min_arg:
             self._arg_max = args.max
@@ -190,16 +190,16 @@ class Command:
         ap = argparse.ArgumentParser(description=self._DESC)
 
         # common arguments
-        ap.add_argument('path', metavar="<path/to/trace>", help='trace path')
+        ap.add_argument('path', metavar='<path/to/trace>', help='trace path')
         ap.add_argument('-r', '--refresh', type=int,
                         help='Refresh period in seconds')
         ap.add_argument('--limit', type=int, default=10,
                         help='Limit to top X (default = 10)')
-        ap.add_argument('--no-progress', action="store_true",
+        ap.add_argument('--no-progress', action='store_true',
                         help='Don\'t display the progress bar')
-        ap.add_argument('--skip-validation', action="store_true",
+        ap.add_argument('--skip-validation', action='store_true',
                         help='Skip the trace validation')
-        ap.add_argument('--gmt', action="store_true",
+        ap.add_argument('--gmt', action='store_true',
                         help='Manipulate timestamps based on GMT instead '
                              'of local time')
         ap.add_argument('--begin', type=str, help='start time: '
@@ -232,7 +232,7 @@ class Command:
                                  'less that minsize bytes')
 
         if self._enable_freq_arg:
-            ap.add_argument('--freq', action="store_true",
+            ap.add_argument('--freq', action='store_true',
                             help='Show the frequency distribution of '
                                  'handler duration')
             ap.add_argument('--freq-resolution', type=int, default=20,
@@ -240,12 +240,12 @@ class Command:
                                  '(default 20)')
 
         if self._enable_log_arg:
-            ap.add_argument('--log', action="store_true",
+            ap.add_argument('--log', action='store_true',
                             help='Display the events in the order they '
                                  'appeared')
 
         if self._enable_stats_arg:
-            ap.add_argument('--stats', action="store_true",
+            ap.add_argument('--stats', action='store_true',
                             help='Display the statistics')
 
         # specific arguments

--- a/lttnganalysescli/lttnganalysescli/command.py
+++ b/lttnganalysescli/lttnganalysescli/command.py
@@ -122,7 +122,7 @@ class Command:
 
     def _check_refresh(self, event, refresh_cb):
         """Check if we need to output something"""
-        if self._arg_refresh == 0:
+        if self._arg_refresh is None:
             return
         event_sec = event.timestamp / common.NSEC_PER_SEC
         if self.current_sec == 0:
@@ -135,20 +135,26 @@ class Command:
 
     def _validate_transform_common_args(self, args):
         self._arg_path = args.path
+
         if args.limit:
             self._arg_limit = args.limit
+
         self._arg_begin = None
         if args.begin:
             self._arg_begin = args.begin
+
         self._arg_end = None
         if args.end:
             self._arg_end = args.end
+
         self._arg_timerange = None
         if args.timerange:
             self._arg_timerange = args.timerange
+
         self._arg_gmt = None
         if args.gmt:
             self._arg_gmt = args.gmt
+
         self._arg_refresh = args.refresh
         self._arg_no_progress = args.no_progress
         self._arg_skip_validation = args.skip_validation
@@ -157,6 +163,7 @@ class Command:
             self._arg_proc_list = None
             if args.procname:
                 self._arg_proc_list = args.procname.split(",")
+
             self._arg_pid_list = None
             if args.pid:
                 self._arg_pid_list = args.pid.split(",")
@@ -185,7 +192,7 @@ class Command:
         # common arguments
         ap.add_argument('path', metavar="<path/to/trace>", help='trace path')
         ap.add_argument('-r', '--refresh', type=int,
-                        help='Refresh period in seconds', default=0)
+                        help='Refresh period in seconds')
         ap.add_argument('--limit', type=int, default=10,
                         help='Limit to top X (default = 10)')
         ap.add_argument('--no-progress', action="store_true",
@@ -203,24 +210,24 @@ class Command:
                                                       '[begin,end]')
 
         if self._enable_proc_filter_args:
-            ap.add_argument('--procname', type=str, default=0,
+            ap.add_argument('--procname', type=str,
                             help='Filter the results only for this list of '
                                  'process names')
-            ap.add_argument('--pid', type=str, default=0,
+            ap.add_argument('--pid', type=str,
                             help='Filter the results only for this list '
                                  'of PIDs')
 
         if self._enable_max_min_arg:
-            ap.add_argument('--max', type=float, default=-1,
+            ap.add_argument('--max', type=float,
                             help='Filter out, duration longer than max usec')
-            ap.add_argument('--min', type=float, default=-1,
+            ap.add_argument('--min', type=float,
                             help='Filter out, duration shorter than min usec')
 
         if self._enable_max_min_size_arg:
-            ap.add_argument('--maxsize', type=float, default=-1,
+            ap.add_argument('--maxsize', type=float,
                             help='Filter out, I/O operations working with '
                                  'more that maxsize bytes')
-            ap.add_argument('--minsize', type=float, default=-1,
+            ap.add_argument('--minsize', type=float,
                             help='Filter out, I/O operations working with '
                                  'less that minsize bytes')
 

--- a/lttnganalysescli/lttnganalysescli/command.py
+++ b/lttnganalysescli/lttnganalysescli/command.py
@@ -162,24 +162,12 @@ class Command:
                 self._arg_pid_list = args.pid.split(",")
 
         if self._enable_max_min_arg:
-            if args.max == -1:
-                self._arg_max = None
-            else:
-                self._arg_max = args.max
-            if args.min == -1:
-                self._arg_min = None
-            else:
-                self._arg_min = args.min
+            self._arg_max = args.max
+            self._arg_min = args.min
 
         if self._enable_max_min_size_arg:
-            if args.maxsize == -1:
-                self._arg_maxsize = None
-            else:
-                self._arg_maxsize = args.maxsize
-            if args.minsize == -1:
-                self._arg_minsize = None
-            else:
-                self._arg_minsize = args.minsize
+            self._arg_maxsize = args.maxsize
+            self._arg_minsize = args.minsize
 
         if self._enable_freq_arg:
             self._arg_freq = args.freq

--- a/lttnganalysescli/lttnganalysescli/command.py
+++ b/lttnganalysescli/lttnganalysescli/command.py
@@ -265,3 +265,4 @@ class Command:
 
     def _create_automaton(self):
         self._automaton = linuxautomaton.automaton.Automaton()
+        self.state = self._automaton.state

--- a/lttnganalysescli/lttnganalysescli/command.py
+++ b/lttnganalysescli/lttnganalysescli/command.py
@@ -88,15 +88,15 @@ class Command:
         self.current_sec = 0
         self.start_ns = 0
         self.end_ns = 0
-        started = 0
+        started = False
         progressbar.progressbar_setup(self)
         if not self._arg_begin:
-            started = 1
+            started = True
         for event in self._traces.events:
             progressbar.progressbar_update(self)
-            if self._arg_begin and started == 0 and \
+            if self._arg_begin and not started and \
                     event.timestamp >= self._arg_begin:
-                started = 1
+                started = True
                 self.trace_start_ts = event.timestamp
                 self.start_ns = event.timestamp
                 reset_cb(event.timestamp)

--- a/lttnganalysescli/lttnganalysescli/cputop.py
+++ b/lttnganalysescli/lttnganalysescli/cputop.py
@@ -68,7 +68,7 @@ class Cputop(Command):
                 current_cpu.cpu_ns += self.end_ns - current_cpu.start_task_ns
             cpu_total_ns = current_cpu.cpu_ns
             current_cpu.cpu_pc = (cpu_total_ns * 100)/total_ns
-            if current_cpu.current_tid >= 0:
+            if current_cpu.current_tid is not None:
                 self.state.tids[current_cpu.current_tid].cpu_ns += \
                     self.end_ns - current_cpu.start_task_ns
 
@@ -78,7 +78,7 @@ class Cputop(Command):
             current_cpu.cpu_ns = 0
             if current_cpu.start_task_ns != 0:
                 current_cpu.start_task_ns = start_ts
-            if current_cpu.current_tid >= 0:
+            if current_cpu.current_tid is not None:
                 self.state.tids[current_cpu.current_tid].last_sched = start_ts
         for tid in self.state.tids.keys():
             self.state.tids[tid].cpu_ns = 0

--- a/lttnganalysescli/lttnganalysescli/cputop.py
+++ b/lttnganalysescli/lttnganalysescli/cputop.py
@@ -53,7 +53,7 @@ class Cputop(Command):
         # process the results
         self._compute_stats()
         # print results
-        self._print_results(self.start_ns, self.trace_end_ts, final=1)
+        self._print_results(self.start_ns, self.trace_end_ts)
         # close the trace
         self._close_trace()
 
@@ -90,10 +90,10 @@ class Cputop(Command):
 
     def _refresh(self, begin, end):
         self._compute_stats()
-        self._print_results(begin, end, final=0)
+        self._print_results(begin, end)
         self._reset_total(end)
 
-    def _print_results(self, begin_ns, end_ns, final=0):
+    def _print_results(self, begin_ns, end_ns):
 #        print('event count: {}'.format(self._analysis.event_count))
         count = 0
         limit = self._arg_limit

--- a/lttnganalysescli/lttnganalysescli/cputop.py
+++ b/lttnganalysescli/lttnganalysescli/cputop.py
@@ -58,10 +58,9 @@ class Cputop(Command):
         self._close_trace()
 
     def _create_analysis(self):
-        self._analysis = lttnganalyses.cputop.Cputop(self._automaton.state)
+        self._analysis = lttnganalyses.cputop.Cputop(self.state)
 
     def _compute_stats(self):
-        self.state = self._automaton.state
         for cpu in self.state.cpus.keys():
             current_cpu = self.state.cpus[cpu]
             total_ns = self.end_ns - self.start_ns
@@ -74,7 +73,6 @@ class Cputop(Command):
                     self.end_ns - current_cpu.start_task_ns
 
     def _reset_total(self, start_ts):
-        self.state = self._automaton.state
         for cpu in self.state.cpus.keys():
             current_cpu = self.state.cpus[cpu]
             current_cpu.cpu_ns = 0

--- a/lttnganalysescli/lttnganalysescli/cputop.py
+++ b/lttnganalysescli/lttnganalysescli/cputop.py
@@ -111,28 +111,28 @@ class Cputop(Command):
                 continue
             if tid.tid == 0:
                 continue
-            pc = float("%0.02f" % ((tid.cpu_ns * 100) / total_ns))
+            pc = float('%0.02f' % ((tid.cpu_ns * 100) / total_ns))
             if tid.migrate_count > 0:
-                migrations = ", %d migrations" % (tid.migrate_count)
+                migrations = ', %d migrations' % (tid.migrate_count)
             else:
-                migrations = ""
-            values.append(("%s (%d)%s" % (tid.comm, tid.tid, migrations), pc))
+                migrations = ''
+            values.append(('%s (%d)%s' % (tid.comm, tid.tid, migrations), pc))
             count = count + 1
             if limit > 0 and count >= limit:
                 break
-        for line in graph.graph("Per-TID CPU Usage", values, unit=" %"):
+        for line in graph.graph('Per-TID CPU Usage', values, unit=' %'):
             print(line)
 
         values = []
         total_cpu_pc = 0
         for cpu in sorted(self.state.cpus.values(),
                           key=operator.attrgetter('cpu_ns'), reverse=True):
-            cpu_pc = float("%0.02f" % cpu.cpu_pc)
+            cpu_pc = float('%0.02f' % cpu.cpu_pc)
             total_cpu_pc += cpu_pc
-            values.append(("CPU %d" % cpu.cpu_id, cpu_pc))
-        for line in graph.graph("Per-CPU Usage", values, unit=" %"):
+            values.append(('CPU %d' % cpu.cpu_id, cpu_pc))
+        for line in graph.graph('Per-CPU Usage', values, unit=' %'):
             print(line)
-        print("\nTotal CPU Usage: %0.02f%%\n" %
+        print('\nTotal CPU Usage: %0.02f%%\n' %
               (total_cpu_pc / len(self.state.cpus.keys())))
 
     def _add_arguments(self, ap):

--- a/lttnganalysescli/lttnganalysescli/cputop.py
+++ b/lttnganalysescli/lttnganalysescli/cputop.py
@@ -94,7 +94,6 @@ class Cputop(Command):
         self._reset_total(end)
 
     def _print_results(self, begin_ns, end_ns):
-#        print('event count: {}'.format(self._analysis.event_count))
         count = 0
         limit = self._arg_limit
         total_ns = end_ns - begin_ns

--- a/lttnganalysescli/lttnganalysescli/io.py
+++ b/lttnganalysescli/lttnganalysescli/io.py
@@ -99,9 +99,7 @@ class IoAnalysis(Command):
         self.run(usage=True)
 
     def _create_analysis(self):
-        self._analysis = lttnganalyses.syscalls.SyscallsAnalysis(
-            self._automaton.state)
-        self.state = self._automaton.state
+        self._analysis = lttnganalyses.syscalls.SyscallsAnalysis(self.state)
 
     def _compute_stats(self):
         pass

--- a/lttnganalysescli/lttnganalysescli/io.py
+++ b/lttnganalysescli/lttnganalysescli/io.py
@@ -79,7 +79,7 @@ class IoAnalysis(Command):
         # process the results
         self._compute_stats()
         # print results
-        self._print_results(self.start_ns, self.trace_end_ts, final=1)
+        self._print_results(self.start_ns, self.trace_end_ts)
         # close the trace
         self._close_trace()
 
@@ -111,7 +111,7 @@ class IoAnalysis(Command):
 
     def _refresh(self, begin, end):
         self._compute_stats()
-        self._print_results(begin, end, final=0)
+        self._print_results(begin, end)
         self._reset_total(end)
 
     def add_fd_dict(self, tid, fd, files):
@@ -750,7 +750,7 @@ class IoAnalysis(Command):
         self.iostats_output_syscalls()
         self.iostats_output_disk()
 
-    def _print_results(self, begin_ns, end_ns, final=0):
+    def _print_results(self, begin_ns, end_ns):
         print('Timerange: [%s, %s]' % (
             common.ns_to_hour_nsec(begin_ns, gmt=self._arg_gmt,
                                    multi_day=True),

--- a/lttnganalysescli/lttnganalysescli/io.py
+++ b/lttnganalysescli/lttnganalysescli/io.py
@@ -609,7 +609,7 @@ class IoAnalysis(Command):
         limit = self._arg_limit
         count = 0
         outrange_legend = False
-        if len(rq_list) == 0:
+        if not rq_list:
             return
         print(title)
         if self._arg_extra:
@@ -697,7 +697,7 @@ class IoAnalysis(Command):
     # iostats functions
     def iostats_output_disk(self):
         # TODO same with network
-        if len(self.state.disks.keys()) == 0:
+        if not self.state.disks:
             return
         print("\nDisk latency statistics (usec):")
         fmt = "{:<14} {:>14} {:>14} {:>14} {:>14} {:>14}"

--- a/lttnganalysescli/lttnganalysescli/io.py
+++ b/lttnganalysescli/lttnganalysescli/io.py
@@ -438,7 +438,7 @@ class IoAnalysis(Command):
 
     def compute_disk_stats(self, dev):
         _max = 0
-        _min = -1
+        _min = None
         total = 0
         values = []
         count = len(dev.rq_list)
@@ -447,7 +447,7 @@ class IoAnalysis(Command):
         for rq in dev.rq_list:
             if rq.duration > _max:
                 _max = rq.duration
-            if _min == -1 or rq.duration < _min:
+            if _min is None or rq.duration < _min:
                 _min = rq.duration
             total += rq.duration
             values.append(rq.duration)

--- a/lttnganalysescli/lttnganalysescli/io.py
+++ b/lttnganalysescli/lttnganalysescli/io.py
@@ -293,21 +293,39 @@ class IoAnalysis(Command):
         limit = self._arg_limit
         graph = Pyasciigraph()
         values = []
+
         for tid in sorted(self.state.tids.values(),
-                          key=operator.attrgetter('block_read'), reverse=True):
+                          key=operator.attrgetter('block_read'),
+                          reverse=True):
+
             if not self.filter_process(tid):
                 continue
+
             if tid.block_read == 0:
                 continue
+
             info_fmt = "{:>10} {:<22}"
-            values.append((info_fmt.format(common.convert_size(tid.block_read,
-                                           padding_after=True),
-                                           "%s (pid=%d)" % (tid.comm,
-                                                            tid.pid)),
+
+            comm = tid.comm
+            if not comm:
+                comm = "unknown"
+
+            pid = tid.pid
+            if not pid:
+                pid = "unknown"
+            else:
+                pid = str(pid)
+
+            values.append((info_fmt.format(
+                common.convert_size(tid.block_read, padding_after=True),
+                "%s (pid=%s)" % (comm, pid)),
                            tid.block_read))
+
             count = count + 1
+
             if limit > 0 and count >= limit:
                 break
+
         for line in graph.graph('Block I/O Read', values, with_value=False):
             print(line)
 
@@ -316,22 +334,39 @@ class IoAnalysis(Command):
         limit = self._arg_limit
         graph = Pyasciigraph()
         values = []
+
         for tid in sorted(self.state.tids.values(),
                           key=operator.attrgetter('block_write'),
                           reverse=True):
+
             if not self.filter_process(tid):
                 continue
+
             if tid.block_write == 0:
                 continue
+
             info_fmt = "{:>10} {:<22}"
-            values.append((info_fmt.format(common.convert_size(tid.block_write,
-                                           padding_after=True),
-                                           "%s (pid=%d)" % (tid.comm,
-                                                            tid.pid)),
+
+            comm = tid.comm
+            if not comm:
+                comm = "unknown"
+
+            pid = tid.pid
+            if not pid:
+                pid = "unknown"
+            else:
+                pid = str(pid)
+
+            values.append((info_fmt.format(
+                common.convert_size(tid.block_write, padding_after=True),
+                "%s (pid=%s)" % (comm, pid)),
                            tid.block_write))
+
             count = count + 1
+
             if limit > 0 and count >= limit:
                 break
+
         for line in graph.graph('Block I/O Write', values, with_value=False):
             print(line)
 

--- a/lttnganalysescli/lttnganalysescli/io.py
+++ b/lttnganalysescli/lttnganalysescli/io.py
@@ -117,32 +117,32 @@ class IoAnalysis(Command):
     def add_fd_dict(self, tid, fd, files):
         if fd.read == 0 and fd.write == 0:
             return
-        if fd.filename.startswith("pipe") or \
-                fd.filename.startswith("socket") or \
-                fd.filename.startswith("anon_inode") or \
-                fd.filename.startswith("unknown"):
-            filename = "%s (%s)" % (fd.filename, tid.comm)
+        if fd.filename.startswith('pipe') or \
+                fd.filename.startswith('socket') or \
+                fd.filename.startswith('anon_inode') or \
+                fd.filename.startswith('unknown'):
+            filename = '%s (%s)' % (fd.filename, tid.comm)
             files[filename] = {}
-            files[filename]["read"] = fd.read
-            files[filename]["write"] = fd.write
-            files[filename]["name"] = filename
-            files[filename]["other"] = ["fd %d in %s (%d)" % (fd.fd,
+            files[filename]['read'] = fd.read
+            files[filename]['write'] = fd.write
+            files[filename]['name'] = filename
+            files[filename]['other'] = ['fd %d in %s (%d)' % (fd.fd,
                                         tid.comm, tid.pid)]
         else:
             # merge counters of shared files
             filename = fd.filename
             if filename not in files.keys():
                 files[filename] = {}
-                files[filename]["read"] = fd.read
-                files[filename]["write"] = fd.write
-                files[filename]["name"] = filename
-                files[filename]["other"] = ["fd %d in %s (%d)" %
+                files[filename]['read'] = fd.read
+                files[filename]['write'] = fd.write
+                files[filename]['name'] = filename
+                files[filename]['other'] = ['fd %d in %s (%d)' %
                                             (fd.fd, tid.comm, tid.pid)]
-                files[filename]["tids"] = [tid.tid]
+                files[filename]['tids'] = [tid.tid]
             else:
-                files[filename]["read"] += fd.read
-                files[filename]["write"] += fd.write
-                files[filename]["other"].append("fd %d in %s (%d)" %
+                files[filename]['read'] += fd.read
+                files[filename]['write'] += fd.write
+                files[filename]['other'].append('fd %d in %s (%d)' %
                                                 (fd.fd, tid.comm,
                                                  tid.pid))
 
@@ -166,14 +166,14 @@ class IoAnalysis(Command):
         sorted_f = sorted(files.items(), key=lambda files: files[1]['read'],
                           reverse=True)
         for f in sorted_f:
-            if f[1]["read"] == 0:
+            if f[1]['read'] == 0:
                 continue
-            info_fmt = "{:>10}".format(common.convert_size(f[1]["read"],
+            info_fmt = '{:>10}'.format(common.convert_size(f[1]['read'],
                                        padding_after=True))
-            values.append(("%s %s %s" % (info_fmt,
-                                         f[1]["name"],
-                                         str(f[1]["other"])[1:-1]),
-                           f[1]["read"]))
+            values.append(('%s %s %s' % (info_fmt,
+                                         f[1]['name'],
+                                         str(f[1]['other'])[1:-1]),
+                           f[1]['read']))
             count = count + 1
             if limit > 0 and count >= limit:
                 break
@@ -190,14 +190,14 @@ class IoAnalysis(Command):
         sorted_f = sorted(files.items(), key=lambda files: files[1]['write'],
                           reverse=True)
         for f in sorted_f:
-            if f[1]["write"] == 0:
+            if f[1]['write'] == 0:
                 continue
-            info_fmt = "{:>10}".format(common.convert_size(f[1]["write"],
+            info_fmt = '{:>10}'.format(common.convert_size(f[1]['write'],
                                        padding_after=True))
-            values.append(("%s %s %s" % (info_fmt,
-                                         f[1]["name"],
-                                         str(f[1]["other"])[1:-1]),
-                           f[1]["write"]))
+            values.append(('%s %s %s' % (info_fmt,
+                                         f[1]['name'],
+                                         str(f[1]['other'])[1:-1]),
+                           f[1]['write']))
             count = count + 1
             if limit > 0 and count >= limit:
                 break
@@ -243,10 +243,10 @@ class IoAnalysis(Command):
                           key=operator.attrgetter('read'), reverse=True):
             if not self.filter_process(tid):
                 continue
-            info_fmt = "{:>10} {:<25} {:>9} file {:>9} net {:>9} unknown"
+            info_fmt = '{:>10} {:<25} {:>9} file {:>9} net {:>9} unknown'
             values.append((info_fmt.format(
                            common.convert_size(tid.read, padding_after=True),
-                           "%s (%d)" % (tid.comm, tid.pid),
+                           '%s (%d)' % (tid.comm, tid.pid),
                            common.convert_size(tid.disk_read,
                                                padding_after=True),
                            common.convert_size(tid.net_read,
@@ -270,10 +270,10 @@ class IoAnalysis(Command):
                           key=operator.attrgetter('write'), reverse=True):
             if not self.filter_process(tid):
                 continue
-            info_fmt = "{:>10} {:<25} {:>9} file {:>9} net {:>9} unknown "
+            info_fmt = '{:>10} {:<25} {:>9} file {:>9} net {:>9} unknown '
             values.append((info_fmt.format(
                            common.convert_size(tid.write, padding_after=True),
-                           "%s (%d)" % (tid.comm, tid.pid),
+                           '%s (%d)' % (tid.comm, tid.pid),
                            common.convert_size(tid.disk_write,
                                                padding_after=True),
                            common.convert_size(tid.net_write,
@@ -304,21 +304,21 @@ class IoAnalysis(Command):
             if tid.block_read == 0:
                 continue
 
-            info_fmt = "{:>10} {:<22}"
+            info_fmt = '{:>10} {:<22}'
 
             comm = tid.comm
             if not comm:
-                comm = "unknown"
+                comm = 'unknown'
 
             pid = tid.pid
             if not pid:
-                pid = "unknown"
+                pid = 'unknown'
             else:
                 pid = str(pid)
 
             values.append((info_fmt.format(
                 common.convert_size(tid.block_read, padding_after=True),
-                "%s (pid=%s)" % (comm, pid)),
+                '%s (pid=%s)' % (comm, pid)),
                            tid.block_read))
 
             count = count + 1
@@ -345,21 +345,21 @@ class IoAnalysis(Command):
             if tid.block_write == 0:
                 continue
 
-            info_fmt = "{:>10} {:<22}"
+            info_fmt = '{:>10} {:<22}'
 
             comm = tid.comm
             if not comm:
-                comm = "unknown"
+                comm = 'unknown'
 
             pid = tid.pid
             if not pid:
-                pid = "unknown"
+                pid = 'unknown'
             else:
                 pid = str(pid)
 
             values.append((info_fmt.format(
                 common.convert_size(tid.block_write, padding_after=True),
-                "%s (pid=%s)" % (comm, pid)),
+                '%s (pid=%s)' % (comm, pid)),
                            tid.block_write))
 
             count = count + 1
@@ -378,7 +378,7 @@ class IoAnalysis(Command):
             if disk.nr_sector == 0:
                 continue
             values.append((disk.prettyname, disk.nr_sector))
-        for line in graph.graph('Disk nr_sector', values, unit=" sectors"):
+        for line in graph.graph('Disk nr_sector', values, unit=' sectors'):
             print(line)
 
     def iotop_output_nr_requests(self):
@@ -390,7 +390,7 @@ class IoAnalysis(Command):
             if disk.nr_sector == 0:
                 continue
             values.append((disk.prettyname, disk.nr_requests))
-        for line in graph.graph('Disk nr_requests', values, unit=" requests"):
+        for line in graph.graph('Disk nr_requests', values, unit=' requests'):
             print(line)
 
     def iotop_output_dev_latency(self):
@@ -401,10 +401,10 @@ class IoAnalysis(Command):
                 continue
             total = (disk.request_time / disk.completed_requests) \
                 / common.MSEC_PER_NSEC
-            total = float("%0.03f" % total)
-            values.append(("%s" % disk.prettyname, total))
+            total = float('%0.03f' % total)
+            values.append(('%s' % disk.prettyname, total))
         for line in graph.graph('Disk request time/sector', values, sort=2,
-                                unit=" ms"):
+                                unit=' ms'):
             print(line)
 
     def iotop_output_net_recv_bytes(self):
@@ -413,7 +413,7 @@ class IoAnalysis(Command):
         for iface in sorted(self.state.ifaces.values(),
                             key=operator.attrgetter('recv_bytes'),
                             reverse=True):
-            values.append(("%s %s" % (common.convert_size(iface.recv_bytes),
+            values.append(('%s %s' % (common.convert_size(iface.recv_bytes),
                                       iface.name),
                           iface.recv_bytes))
         for line in graph.graph('Network recv_bytes', values,
@@ -426,7 +426,7 @@ class IoAnalysis(Command):
         for iface in sorted(self.state.ifaces.values(),
                             key=operator.attrgetter('send_bytes'),
                             reverse=True):
-            values.append(("%s %s" % (common.convert_size(iface.send_bytes),
+            values.append(('%s %s' % (common.convert_size(iface.send_bytes),
                                       iface.name),
                           iface.send_bytes))
         for line in graph.graph('Network sent_bytes', values,
@@ -463,11 +463,11 @@ class IoAnalysis(Command):
         g = []
         i = 0
         for v in values:
-            g.append(("%0.03f" % (i * step + _min), v))
+            g.append(('%0.03f' % (i * step + _min), v))
             i += 1
         for line in graph.graph(title, g, info_before=True, count=True):
             print(line)
-        print("")
+        print('')
 
     def compute_disk_stats(self, dev):
         _max = 0
@@ -487,7 +487,7 @@ class IoAnalysis(Command):
         if count > 2:
             stdev = statistics.stdev(values) / 1000
         else:
-            stdev = "?"
+            stdev = '?'
         dev.min = _min / 1000
         dev.max = _max / 1000
         dev.total = total / 1000
@@ -505,8 +505,8 @@ class IoAnalysis(Command):
                 self.iolatency_freq_histogram(d.min, d.max,
                                               self._arg_freq_resolution,
                                               d.rq_values,
-                                              "Frequency distribution for "
-                                              "disk %s (usec)" %
+                                              'Frequency distribution for '
+                                              'disk %s (usec)' %
                                               (d.prettyname))
 
     def iolatency_output(self):
@@ -517,9 +517,9 @@ class IoAnalysis(Command):
 #        for proc in self.latency_hist.keys():
 #            values = []
 #            for v in self.latency_hist[proc]:
-#                values.append(("%s" % (v[0]), v[1]))
+#                values.append(('%s' % (v[0]), v[1]))
 #            for line in graph.graph('%s requests latency (ms)' % proc, values,
-#                                    unit=" ms"):
+#                                    unit=' ms'):
 #                print(line)
 
     def iostats_minmax(self, duration, current_min, current_max):
@@ -533,17 +533,17 @@ class IoAnalysis(Command):
 
     def iostats_syscalls_line(self, fmt, name, count, _min, _max, total, rq):
         if count < 2:
-            stdev = "?"
+            stdev = '?'
         else:
-            stdev = "%0.03f" % (statistics.stdev(rq) / 1000)
+            stdev = '%0.03f' % (statistics.stdev(rq) / 1000)
         if count < 1:
-            avg = "0.000"
+            avg = '0.000'
         else:
-            avg = "%0.03f" % (total / (count * 1000))
+            avg = '%0.03f' % (total / (count * 1000))
         if _min is None:
             _min = 0
-        _min = "%0.03f" % (_min / 1000)
-        _max = "%0.03f" % (_max / 1000)
+        _min = '%0.03f' % (_min / 1000)
+        _max = '%0.03f' % (_max / 1000)
         print(fmt.format(name, count, _min, avg, _max, stdev))
 
     def account_syscall_iorequests(self, s, iorequests):
@@ -602,40 +602,40 @@ class IoAnalysis(Command):
 
     def iostats_output_syscalls(self):
         s = self.syscalls_stats
-        print("\nSyscalls latency statistics (usec):")
-        fmt = "{:<14} {:>14} {:>14} {:>14} {:>14} {:>14}"
-        print(fmt.format("Type", "Count", "Min", "Average",
-                         "Max", "Stdev"))
-        print("-" * 89)
-        self.iostats_syscalls_line(fmt, "Open", s.open_count, s.open_min,
+        print('\nSyscalls latency statistics (usec):')
+        fmt = '{:<14} {:>14} {:>14} {:>14} {:>14} {:>14}'
+        print(fmt.format('Type', 'Count', 'Min', 'Average',
+                         'Max', 'Stdev'))
+        print('-' * 89)
+        self.iostats_syscalls_line(fmt, 'Open', s.open_count, s.open_min,
                                    s.open_max, s.open_total, s.open_rq)
-        self.iostats_syscalls_line(fmt, "Read", s.read_count, s.read_min,
+        self.iostats_syscalls_line(fmt, 'Read', s.read_count, s.read_min,
                                    s.read_max, s.read_total, s.read_rq)
-        self.iostats_syscalls_line(fmt, "Write", s.write_count, s.write_min,
+        self.iostats_syscalls_line(fmt, 'Write', s.write_count, s.write_min,
                                    s.write_max, s.write_total, s.write_rq)
-        self.iostats_syscalls_line(fmt, "Sync", s.sync_count, s.sync_min,
+        self.iostats_syscalls_line(fmt, 'Sync', s.sync_count, s.sync_min,
                                    s.sync_max, s.sync_total, s.sync_rq)
 
     def iolatency_syscalls_output(self):
         s = self.syscalls_stats
-        print("")
+        print('')
         if s.open_count > 0:
             self.iolatency_freq_histogram(s.open_min/1000, s.open_max/1000,
                                           self._arg_freq_resolution, s.open_rq,
-                                          "Open latency distribution (usec)")
+                                          'Open latency distribution (usec)')
         if s.read_count > 0:
             self.iolatency_freq_histogram(s.read_min/1000, s.read_max/1000,
                                           self._arg_freq_resolution, s.read_rq,
-                                          "Read latency distribution (usec)")
+                                          'Read latency distribution (usec)')
         if s.write_count > 0:
             self.iolatency_freq_histogram(s.write_min/1000, s.write_max/1000,
                                           self._arg_freq_resolution,
                                           s.write_rq,
-                                          "Write latency distribution (usec)")
+                                          'Write latency distribution (usec)')
         if s.sync_count > 0:
             self.iolatency_freq_histogram(s.sync_min/1000, s.sync_max/1000,
                                           self._arg_freq_resolution, s.sync_rq,
-                                          "Sync latency distribution (usec)")
+                                          'Sync latency distribution (usec)')
 
     def iolatency_syscalls_list_output(self, title, rq_list,
                                        sortkey, reverse):
@@ -646,96 +646,96 @@ class IoAnalysis(Command):
             return
         print(title)
         if self._arg_extra:
-            extra_fmt = "{:<48}"
-            extra_title = "{:<8} {:<8} {:<8} {:<8} {:<8} {:<8} ".format(
-                "Dirtied", "Alloc", "Free", "Written", "Kswap", "Cleared")
+            extra_fmt = '{:<48}'
+            extra_title = '{:<8} {:<8} {:<8} {:<8} {:<8} {:<8} '.format(
+                'Dirtied', 'Alloc', 'Free', 'Written', 'Kswap', 'Cleared')
         else:
-            extra_fmt = "{:<0}"
-            extra_title = ""
-        title_fmt = "{:<19} {:<20} {:<16} {:<23} {:<5} {:<24} {:<8} " + \
-            extra_fmt + "{:<14}"
-        fmt = "{:<40} {:<16} {:>16} {:>11}  {:<24} {:<8} " + \
-            extra_fmt + "{:<14}"
-        print(title_fmt.format("Begin", "End", "Name", "Duration (usec)",
-                               "Size", "Proc", "PID", extra_title, "Filename"))
+            extra_fmt = '{:<0}'
+            extra_title = ''
+        title_fmt = '{:<19} {:<20} {:<16} {:<23} {:<5} {:<24} {:<8} ' + \
+            extra_fmt + '{:<14}'
+        fmt = '{:<40} {:<16} {:>16} {:>11}  {:<24} {:<8} ' + \
+            extra_fmt + '{:<14}'
+        print(title_fmt.format('Begin', 'End', 'Name', 'Duration (usec)',
+                               'Size', 'Proc', 'PID', extra_title, 'Filename'))
         for rq in sorted(rq_list,
                          key=operator.attrgetter(sortkey), reverse=reverse):
-            # only limit the output if in the "top" view
+            # only limit the output if in the 'top' view
             if reverse and count > limit:
                 break
             if rq.size is None:
-                size = "N/A"
+                size = 'N/A'
             else:
                 size = common.convert_size(rq.size)
             if self._arg_extra:
-                extra = "{:<8} {:<8} {:<8} {:<8} {:<8} {:<8} ".format(
+                extra = '{:<8} {:<8} {:<8} {:<8} {:<8} {:<8} '.format(
                     rq.dirty, rq.page_alloc, rq.page_free, rq.page_written,
                     rq.woke_kswapd, rq.page_cleared)
             else:
-                extra = ""
-            name = rq.name.replace("syscall_entry_", "").replace("sys_", "")
+                extra = ''
+            name = rq.name.replace('syscall_entry_', '').replace('sys_', '')
             if rq.fd is None:
-                filename = "None"
-                fd = "None"
+                filename = 'None'
+                fd = 'None'
             else:
                 filename = rq.fd.filename
                 fd = rq.fd.fd
             end = common.ns_to_hour_nsec(rq.end, self._arg_multi_day,
                                          self._arg_gmt)
 
-            outrange = " "
+            outrange = ' '
             duration = rq.duration
             if self._arg_begin and rq.begin < self._arg_begin:
-                outrange = "*"
+                outrange = '*'
                 outrange_legend = True
             if self._arg_end and rq.end > self._arg_end:
-                outrange = "*"
+                outrange = '*'
                 outrange_legend = True
 
-            print(fmt.format("[" + common.ns_to_hour_nsec(
-                rq.begin, self._arg_multi_day, self._arg_gmt) + "," +
-                end + "]" + outrange,
+            print(fmt.format('[' + common.ns_to_hour_nsec(
+                rq.begin, self._arg_multi_day, self._arg_gmt) + ',' +
+                end + ']' + outrange,
                 name,
-                "%0.03f" % (duration/1000) + outrange,
+                '%0.03f' % (duration/1000) + outrange,
                 size, rq.proc.comm,
                 rq.proc.pid, extra,
-                "%s (fd=%s)" % (filename, fd)))
+                '%s (fd=%s)' % (filename, fd)))
             count += 1
         if outrange_legend:
-            print("*: Syscalls started and/or completed outside of the "
-                  "range specified")
+            print('*: Syscalls started and/or completed outside of the '
+                  'range specified')
 
     def iolatency_syscalls_top_output(self):
         s = self.syscalls_stats
         self.iolatency_syscalls_list_output(
-            "\nTop open syscall latencies (usec)", s.all_open,
-            "duration", True)
+            '\nTop open syscall latencies (usec)', s.all_open,
+            'duration', True)
         self.iolatency_syscalls_list_output(
-            "\nTop read syscall latencies (usec)", s.all_read,
-            "duration", True)
+            '\nTop read syscall latencies (usec)', s.all_read,
+            'duration', True)
         self.iolatency_syscalls_list_output(
-            "\nTop write syscall latencies (usec)", s.all_write,
-            "duration", True)
+            '\nTop write syscall latencies (usec)', s.all_write,
+            'duration', True)
         self.iolatency_syscalls_list_output(
-            "\nTop sync syscall latencies (usec)", s.all_sync,
-            "duration", True)
+            '\nTop sync syscall latencies (usec)', s.all_sync,
+            'duration', True)
 
     def iolatency_syscalls_log_output(self):
         s = self.syscalls_stats
         self.iolatency_syscalls_list_output(
-            "\nLog of all I/O system calls",
+            '\nLog of all I/O system calls',
             s.all_open + s.all_read + s.all_write + s.all_sync,
-            "begin", False)
+            'begin', False)
 
     # iostats functions
     def iostats_output_disk(self):
         # TODO same with network
         if not self.state.disks:
             return
-        print("\nDisk latency statistics (usec):")
-        fmt = "{:<14} {:>14} {:>14} {:>14} {:>14} {:>14}"
-        print(fmt.format("Name", "Count", "Min", "Average", "Max", "Stdev"))
-        print("-" * 89)
+        print('\nDisk latency statistics (usec):')
+        fmt = '{:<14} {:>14} {:>14} {:>14} {:>14} {:>14}'
+        print(fmt.format('Name', 'Count', 'Min', 'Average', 'Max', 'Stdev'))
+        print('-' * 89)
 
         for dev in self.state.disks.keys():
             d = self.state.disks[dev]
@@ -784,13 +784,13 @@ class IoAnalysis(Command):
             tid.init_counts()
 
     def _add_arguments(self, ap):
-        ap.add_argument('--usage', action="store_true",
+        ap.add_argument('--usage', action='store_true',
                         help='Show the I/O usage')
-        ap.add_argument('--latencystats', action="store_true",
+        ap.add_argument('--latencystats', action='store_true',
                         help='Show the I/O latency statistics')
-        ap.add_argument('--latencytop', action="store_true",
+        ap.add_argument('--latencytop', action='store_true',
                         help='Show the I/O latency top')
-        ap.add_argument('--latencyfreq', action="store_true",
+        ap.add_argument('--latencyfreq', action='store_true',
                         help='Show the I/O latency frequency distribution')
         ap.add_argument('--freq-resolution', type=int, default=20,
                         help='Frequency distribution resolution '

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -182,10 +182,10 @@ class IrqAnalysisCommand(Command):
             if not self._filter_irq(irq):
                 continue
 
+            raise_ts = ''
             if type(irq) is sv.HardIRQ:
                 name = self._analysis.hard_irq_stats[irq.id].name
                 irqtype = 'IRQ'
-                raise_ts = ''
             else:
                 name = self._analysis.softirq_stats[irq.id].name
                 irqtype = 'SoftIRQ'

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -27,6 +27,7 @@ from .command import Command
 import lttnganalyses.irq
 from linuxautomaton import common, sv
 from ascii_graph import Pyasciigraph
+import math
 import statistics
 
 
@@ -95,53 +96,73 @@ class IrqAnalysisCommand(Command):
                                                        self._arg_min,
                                                        self._arg_max)
 
-    def compute_stdev(self, irq):
-        values = []
-        raise_delays = []
-        stdev = {}
-        for j in irq['list']:
-            delay = j.stop_ts - j.start_ts
-            values.append(delay)
-            if j.raise_ts is None:
-                continue
-            # Raise latency (only for some softirqs)
-            r_d = j.start_ts - j.raise_ts
-            raise_delays.append(r_d)
-        if irq['count'] < 2:
-            stdev['duration'] = '?'
-        else:
-            stdev['duration'] = '%0.03f' % (statistics.stdev(values) / 1000)
-        # format string for the raise if present
-        if irq['raise_count'] >= 2:
-            stdev['raise'] = '%0.03f' % (statistics.stdev(raise_delays)/1000)
-        return stdev
+    def _compute_duration_stdev(self, irq_stats_item):
+        if irq_stats_item.count < 2:
+            return float('nan')
 
-    def irq_list_to_freq(self, irq, _min, _max, res, name, nr):
-        step = (_max - _min) / res
+        durations = []
+        for irq in irq_stats_item.irq_list:
+            durations.append(irq.stop_ts - irq.start_ts)
+
+        return statistics.stdev(durations)
+
+    def _compute_raise_latency_stdev(self, irq_stats_item):
+        if irq_stats_item.raise_count < 2:
+            return float('nan')
+
+        raise_latencies = []
+        for irq in irq_stats_item.irq_list:
+            if irq.raise_ts is None:
+                continue
+
+            raise_latencies.append(irq.start_ts - irq.raise_ts)
+
+        return statistics.stdev(raise_latencies)
+
+    def _print_frequency_distribution(self, irq_stats_item, id):
+        # The number of bins for the histogram
+        resolution = self._arg_freq_resolution
+
+        min_duration = irq_stats_item.min_duration
+        max_duration = irq_stats_item.max_duration
+        # ns to µs
+        min_duration /= 1000
+        max_duration /= 1000
+
+        step = (max_duration - min_duration) / resolution
         if step == 0:
             return
+
         buckets = []
         values = []
         graph = Pyasciigraph()
-        for i in range(res):
+        for i in range(resolution):
             buckets.append(i * step)
             values.append(0)
-        for i in irq['list']:
-            v = (i.stop_ts - i.start_ts) / 1000
-            b = min(int((v-_min)/step), res - 1)
-            values[b] += 1
-        g = []
-        i = 0
-        for v in values:
-            g.append(('%0.03f' % (i * step + _min), v))
-            i += 1
-        for line in graph.graph('Handler duration frequency distribution %s '
-                                '(%s) (usec)' % (name, nr),
-                                g, info_before=True, count=True):
-            print(line)
-        print('')
+        for irq in irq_stats_item.irq_list:
+            duration = (irq.stop_ts - irq.start_ts) / 1000
+            index = min(int((duration - min_duration) / step), resolution - 1)
+            values[index] += 1
 
-    def filter_irq(self, irq):
+        graph_data = []
+        for index, value in enumerate(values):
+            # The graph data format is a tuple (info, value). Here info
+            # is the lower bound of the bucket, value the bucket's count
+            graph_data.append(('%0.03f' % (index * step + min_duration),
+                               value))
+
+        graph_lines = graph.graph(
+            'Handler duration frequency distribution %s (%s) (usec)' %
+            (irq_stats_item.name, id),
+            graph_data,
+            info_before=True,
+            count=True
+        )
+
+        for line in graph_lines:
+            print(line)
+
+    def _filter_irq(self, irq):
         if type(irq) is sv.HardIRQ:
             if self._arg_irq_filter_list:
                 return str(irq.id) in self._arg_irq_filter_list
@@ -155,85 +176,134 @@ class IrqAnalysisCommand(Command):
 
         return True
 
-    def log_irq(self):
+    def _print_irq_log(self):
         fmt = '[{:<18}, {:<18}] {:>15} {:>4}  {:<9} {:>4}  {:<22}'
         title_fmt = '{:<20} {:<19} {:>15} {:>4}  {:<9} {:>4}  {:<22}'
         print(title_fmt.format('Begin', 'End', 'Duration (us)', 'CPU',
                                'Type', '#', 'Name'))
-        for i in self.state.interrupts['irq-list']:
-            if not self.filter_irq(i):
+        for irq in self._analysis.irq_list:
+            if not self._filter_irq(irq):
                 continue
-            if i.irqclass == sv.IRQ.HARD_IRQ:
-                name = self.state.interrupts['names'][i.nr]
+
+            if type(irq) is sv.HardIRQ:
+                name = self._analysis.hard_irq_stats[irq.id].name
                 irqtype = 'IRQ'
-            else:
-                name = sv.IRQ.soft_names[i.nr]
-                irqtype = 'SoftIRQ'
-            if i.raise_ts is not None:
-                raise_ts = ' (raised at %s)' % \
-                           (common.ns_to_hour_nsec(i.raise_ts,
-                                                   self._arg_multi_day,
-                                                   self._arg_gmt))
-            else:
                 raise_ts = ''
-            print(fmt.format(common.ns_to_hour_nsec(i.start_ts,
-                                                    self._arg_multi_day,
-                                                    self._arg_gmt),
-                             common.ns_to_hour_nsec(i.stop_ts,
-                                                    self._arg_multi_day,
-                                                    self._arg_gmt),
-                             '%0.03f' % ((i.stop_ts - i.start_ts) / 1000),
-                             '%d' % i.cpu_id, irqtype, i.nr, name + raise_ts))
-
-    def print_irq_stats(self, dic, name_table, filter_list, header):
-        header_output = 0
-        for i in sorted(dic.keys()):
-            if len(filter_list) > 0 and str(i) not in filter_list:
-                continue
-            name = name_table[i]
-            stdev = self.compute_stdev(dic[i])
-
-            # format string for the raise if present
-            if dic[i]['raise_count'] < 2:
-                raise_stats = ' |'
             else:
-                r_avg = dic[i]['raise_total'] / (dic[i]['raise_count'] * 1000)
-                raise_stats = ' | {:>6} {:>12} {:>12} {:>12} {:>12}'.format(
-                    dic[i]['raise_count'],
-                    '%0.03f' % (dic[i]['raise_min'] / 1000),
-                    '%0.03f' % r_avg,
-                    '%0.03f' % (dic[i]['raise_max'] / 1000),
-                    stdev['raise'])
+                name = self._analysis.softirq_stats[irq.id].name
+                irqtype = 'SoftIRQ'
+                if irq.raise_ts is not None:
+                    raise_ts = ' (raised at %s)' % \
+                               (common.ns_to_hour_nsec(irq.raise_ts,
+                                                       self._arg_multi_day,
+                                                       self._arg_gmt))
 
-            # final output
-            if dic[i]['count'] == 0:
+            print(fmt.format(common.ns_to_hour_nsec(irq.start_ts,
+                                                    self._arg_multi_day,
+                                                    self._arg_gmt),
+                             common.ns_to_hour_nsec(irq.stop_ts,
+                                                    self._arg_multi_day,
+                                                    self._arg_gmt),
+                             '%0.03f' % ((irq.stop_ts - irq.start_ts) / 1000),
+                             '%d' % irq.cpu_id, irqtype, irq.id, name + raise_ts))
+
+    def _print_irq_stats(self, irq_stats, filter_list, header):
+        header_printed = False
+        for id in sorted(irq_stats):
+            if filter_list and str(id) not in filter_list:
                 continue
-            avg = '%0.03f' % (dic[i]['total'] / (dic[i]['count'] * 1000))
-            format_str = '{:<3} {:<18} {:>5} {:>12} {:>12} {:>12} ' \
-                         '{:>12} {:<60}'
-            s = format_str.format('%d:' % i, '<%s>' % name, dic[i]['count'],
-                                  '%0.03f' % (dic[i]['min'] / 1000),
-                                  '%s' % (avg),
-                                  '%0.03f' % (dic[i]['max'] / 1000),
-                                  '%s' % (stdev['duration']),
-                                  raise_stats)
-            if self._arg_stats and (self._arg_freq or header_output == 0):
-                print(header)
-                header_output = 1
+
+            irq_stats_item = irq_stats[id]
+            if irq_stats_item.count == 0:
+                continue
+
             if self._arg_stats:
-                print(s)
+                if self._arg_freq or not header_printed:
+                    print(header)
+                    header_printed = True
+
+                if type(irq_stats_item) is lttnganalyses.irq.HardIrqStats:
+                    self._print_hard_irq_stats_item(irq_stats_item, id)
+                else:
+                    self._print_soft_irq_stats_item(irq_stats_item, id)
+
             if self._arg_freq:
-                self.irq_list_to_freq(dic[i], dic[i]['min'] / 1000,
-                                      dic[i]['max'] / 1000,
-                                      self._arg_freq_resolution, name, str(i))
+                self._print_frequency_distribution(irq_stats_item, id)
+
+        print()
+
+    def _print_hard_irq_stats_item(self, irq_stats_item, id):
+        output_str = self._get_duration_stats_str(irq_stats_item, id)
+        print(output_str)
+
+    def _print_soft_irq_stats_item(self, irq_stats_item, id):
+        output_str = self._get_duration_stats_str(irq_stats_item, id)
+        if irq_stats_item.raise_count != 0:
+            output_str += self._get_raise_latency_str(irq_stats_item, id)
+
+        print(output_str)
+
+    def _get_duration_stats_str(self, irq_stats_item, id):
+        format_str = '{:<3} {:<18} {:>5} {:>12} {:>12} {:>12} {:>12} {:<2}'
+
+        avg_duration = irq_stats_item.total_duration / irq_stats_item.count
+        duration_stdev = self._compute_duration_stdev(irq_stats_item)
+        min_duration = irq_stats_item.min_duration
+        max_duration = irq_stats_item.max_duration
+        # ns to µs
+        avg_duration /= 1000
+        duration_stdev /= 1000
+        min_duration /= 1000
+        max_duration /= 1000
+
+        if math.isnan(duration_stdev):
+            duration_stdev_str = '?'
+        else:
+            duration_stdev_str = '%0.03f' % duration_stdev
+
+        output_str = format_str.format('%d:' % id,
+                                       '<%s>' % irq_stats_item.name,
+                                       '%d' % irq_stats_item.count,
+                                       '%0.03f' % min_duration,
+                                       '%0.03f' % avg_duration,
+                                       '%0.03f' % max_duration,
+                                       '%s' % duration_stdev_str,
+                                       ' |')
+        return output_str
+
+    def _get_raise_latency_str(self, irq_stats_item, id):
+        format_str = ' {:>6} {:>12} {:>12} {:>12} {:>12}'
+
+        avg_raise_latency = (irq_stats_item.total_raise_latency /
+                             irq_stats_item.raise_count)
+        raise_latency_stdev = self._compute_raise_latency_stdev(irq_stats_item)
+        min_raise_latency = irq_stats_item.min_raise_latency
+        max_raise_latency = irq_stats_item.max_raise_latency
+        # ns to µs
+        avg_raise_latency /= 1000
+        raise_latency_stdev /= 1000
+        min_raise_latency /= 1000
+        max_raise_latency /= 1000
+
+        if math.isnan(raise_latency_stdev):
+            raise_latency_stdev_str = '?'
+        else:
+            raise_latency_stdev_str = '%0.03f' % raise_latency_stdev
+
+        output_str = format_str.format(irq_stats_item.raise_count,
+                                       '%0.03f' % min_raise_latency,
+                                       '%0.03f' % avg_raise_latency,
+                                       '%0.03f' % max_raise_latency,
+                                       '%s' % raise_latency_stdev_str)
+        return output_str
 
     def _print_results(self, begin_ns, end_ns):
         if self._arg_stats or self._arg_freq:
             self._print_stats(begin_ns, end_ns)
         if self._arg_log:
-            self.log_irq()
+            self._print_irq_log()
 
-    def _print_stats(self, begin_ns, end_ns):
+    def _print_date(self, begin_ns, end_ns):
         date = 'Timerange: [%s, %s]' % (
             common.ns_to_hour_nsec(begin_ns, gmt=self._arg_gmt,
                                    multi_day=True),
@@ -241,46 +311,45 @@ class IrqAnalysisCommand(Command):
                                    multi_day=True))
         print(date)
 
+    def _print_stats(self, begin_ns, end_ns):
+        self._print_date(begin_ns, end_ns)
+
         if self._arg_irq_filter_list is not None:
-            header = ''
-            header += '{:<52} {:<12}\n'.format('Hard IRQ', 'Duration (us)')
-            header += '{:<22} {:<14} {:<12} {:<12} {:<10} ' \
-                      '{:<12}\n'.format('', 'count', 'min', 'avg', 'max',
-                                        'stdev')
-            header += ('-'*82 + '|')
-            self.print_irq_stats(self.state.interrupts['hard-irqs'],
-                                 self.state.interrupts['names'],
-                                 self._arg_irq_filter_list, header)
-            print('')
+            header_format = '{:<52} {:<12}\n' \
+                            '{:<22} {:<14} {:<12} {:<12} {:<10} {:<12}\n'
+            header = header_format.format(
+                'Hard IRQ', 'Duration (us)',
+                '', 'count', 'min', 'avg', 'max', 'stdev'
+            )
+            header += ('-' * 82 + '|')
+            self._print_irq_stats(self._analysis.hard_irq_stats,
+                                  self._arg_irq_filter_list,
+                                  header)
 
         if self._arg_softirq_filter_list is not None:
-            header = ''
-            header += '{:<52} {:<52} {:<12}\n'.format('Soft IRQ',
-                                                      'Duration (us)',
-                                                      'Raise latency (us)')
-            header += '{:<22} {:<14} {:<12} {:<12} {:<10} {:<4} {:<3} {:<14} '\
-                      '{:<12} {:<12} {:<10} ' \
-                      '{:<12}\n'.format('', 'count', 'min', 'avg', 'max',
-                                        'stdev', ' |', 'count', 'min',
-                                        'avg', 'max', 'stdev')
+            header_format = '{:<52} {:<52} {:<12}\n' \
+                            '{:<22} {:<14} {:<12} {:<12} {:<10} {:<4} ' \
+                            '{:<3} {:<14} {:<12} {:<12} {:<10} {:<12}\n'
+            header = header_format.format(
+                'Soft IRQ', 'Duration (us)',
+                'Raise latency (us)', '',
+                'count', 'min', 'avg', 'max', 'stdev', ' |',
+                'count', 'min', 'avg', 'max', 'stdev'
+            )
             header += '-' * 82 + '|' + '-' * 60
-            self.print_irq_stats(self.state.interrupts['soft-irqs'],
-                                 sv.IRQ.soft_names,
+            self._print_irq_stats(self._analysis.softirq_stats,
                                  self._arg_softirq_filter_list,
                                  header)
-            print('')
 
     def _compute_stats(self):
         pass
 
     def _reset_total(self, start_ts):
-        self.state.interrupts['hard_count'] = 0
-        self.state.interrupts['soft_count'] = 0
-        self.state.interrupts['irq-list'] = []
-        for i in self.state.interrupts['hard-irqs'].keys():
-            self.state.interrupts['hard-irqs'][i] = sv.IRQ.init_irq_instance()
-        for i in self.state.interrupts['soft-irqs'].keys():
-            self.state.interrupts['soft-irqs'][i] = sv.IRQ.init_irq_instance()
+        self._analysis.irq_list = []
+        for id in self._analysis.hard_irq_stats:
+            self._analysis.hard_irq_stats[id].reset()
+        for id in self._analysis.softirq_stats:
+            self._analysis.softirq_stats[id].reset()
 
     def _refresh(self, begin, end):
         self._compute_stats()

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -81,7 +81,7 @@ class IrqAnalysis(Command):
         # process the results
         self._compute_stats()
         # print results
-        self._print_results(self.start_ns, self.trace_end_ts, final=1)
+        self._print_results(self.start_ns, self.trace_end_ts)
         # close the trace
         self._close_trace()
 
@@ -239,13 +239,13 @@ class IrqAnalysis(Command):
                                       dic[i]["max"] / 1000,
                                       self._arg_freq_resolution, name, str(i))
 
-    def _print_results(self, begin_ns, end_ns, final=0):
+    def _print_results(self, begin_ns, end_ns):
         if self._arg_stats or self._arg_freq:
-            self._print_stats(begin_ns, end_ns, final)
+            self._print_stats(begin_ns, end_ns)
         if self._arg_log:
             self.log_irq()
 
-    def _print_stats(self, begin_ns, end_ns, final):
+    def _print_stats(self, begin_ns, end_ns):
         if self._arg_no_progress:
             clear_screen = ""
         else:
@@ -299,7 +299,7 @@ class IrqAnalysis(Command):
 
     def _refresh(self, begin, end):
         self._compute_stats()
-        self._print_results(begin, end, final=0)
+        self._print_results(begin, end)
         self._reset_total(end)
 
     def _add_arguments(self, ap):

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -246,16 +246,13 @@ class IrqAnalysis(Command):
             self.log_irq()
 
     def _print_stats(self, begin_ns, end_ns):
-        if self._arg_no_progress:
-            clear_screen = ""
-        else:
-            clear_screen = "\r" + self.pbar.term_width * " " + "\r"
         date = 'Timerange: [%s, %s]' % (
             common.ns_to_hour_nsec(begin_ns, gmt=self._arg_gmt,
                                    multi_day=True),
             common.ns_to_hour_nsec(end_ns, gmt=self._arg_gmt,
                                    multi_day=True))
-        print(clear_screen + date)
+        print(date)
+
         if self._arg_irq_filter_list is not None:
             header = ""
             header += '{:<52} {:<12}\n'.format("Hard IRQ", "Duration (us)")

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -49,9 +49,9 @@ class IrqAnalysis(Command):
         self._arg_irq_filter_list = None
         self._arg_softirq_filter_list = None
         if self._args.irq:
-            self._arg_irq_filter_list = self._args.irq.split(",")
+            self._arg_irq_filter_list = self._args.irq.split(',')
         if self._args.softirq:
-            self._arg_softirq_filter_list = self._args.softirq.split(",")
+            self._arg_softirq_filter_list = self._args.softirq.split(',')
         if self._arg_irq_filter_list is None and \
                 self._arg_softirq_filter_list is None:
             self._arg_irq_filter_list = []
@@ -101,7 +101,7 @@ class IrqAnalysis(Command):
         values = []
         raise_delays = []
         stdev = {}
-        for j in irq["list"]:
+        for j in irq['list']:
             delay = j.stop_ts - j.start_ts
             values.append(delay)
             if j.raise_ts is None:
@@ -109,13 +109,13 @@ class IrqAnalysis(Command):
             # Raise latency (only for some softirqs)
             r_d = j.start_ts - j.raise_ts
             raise_delays.append(r_d)
-        if irq["count"] < 2:
-            stdev["duration"] = "?"
+        if irq['count'] < 2:
+            stdev['duration'] = '?'
         else:
-            stdev["duration"] = "%0.03f" % (statistics.stdev(values) / 1000)
+            stdev['duration'] = '%0.03f' % (statistics.stdev(values) / 1000)
         # format string for the raise if present
-        if irq["raise_count"] >= 2:
-            stdev["raise"] = "%0.03f" % (statistics.stdev(raise_delays)/1000)
+        if irq['raise_count'] >= 2:
+            stdev['raise'] = '%0.03f' % (statistics.stdev(raise_delays)/1000)
         return stdev
 
     def irq_list_to_freq(self, irq, _min, _max, res, name, nr):
@@ -128,20 +128,20 @@ class IrqAnalysis(Command):
         for i in range(res):
             buckets.append(i * step)
             values.append(0)
-        for i in irq["list"]:
+        for i in irq['list']:
             v = (i.stop_ts - i.start_ts) / 1000
             b = min(int((v-_min)/step), res - 1)
             values[b] += 1
         g = []
         i = 0
         for v in values:
-            g.append(("%0.03f" % (i * step + _min), v))
+            g.append(('%0.03f' % (i * step + _min), v))
             i += 1
         for line in graph.graph('Handler duration frequency distribution %s '
                                 '(%s) (usec)' % (name, nr),
                                 g, info_before=True, count=True):
             print(line)
-        print("")
+        print('')
 
     # FIXME: there must be a way to make that more complicated/ugly
     def filter_irq(self, i):
@@ -165,37 +165,37 @@ class IrqAnalysis(Command):
             if self._arg_irq_filter_list is not None and \
                     len(self._arg_irq_filter_list) > 0:
                 return False
-        raise Exception("WTF")
+        raise Exception('WTF')
 
     def log_irq(self):
-        fmt = "[{:<18}, {:<18}] {:>15} {:>4}  {:<9} {:>4}  {:<22}"
-        title_fmt = "{:<20} {:<19} {:>15} {:>4}  {:<9} {:>4}  {:<22}"
-        print(title_fmt.format("Begin", "End", "Duration (us)", "CPU",
-                               "Type", "#", "Name"))
-        for i in self.state.interrupts["irq-list"]:
+        fmt = '[{:<18}, {:<18}] {:>15} {:>4}  {:<9} {:>4}  {:<22}'
+        title_fmt = '{:<20} {:<19} {:>15} {:>4}  {:<9} {:>4}  {:<22}'
+        print(title_fmt.format('Begin', 'End', 'Duration (us)', 'CPU',
+                               'Type', '#', 'Name'))
+        for i in self.state.interrupts['irq-list']:
             if not self.filter_irq(i):
                 continue
             if i.irqclass == sv.IRQ.HARD_IRQ:
-                name = self.state.interrupts["names"][i.nr]
-                irqtype = "IRQ"
+                name = self.state.interrupts['names'][i.nr]
+                irqtype = 'IRQ'
             else:
                 name = sv.IRQ.soft_names[i.nr]
-                irqtype = "SoftIRQ"
+                irqtype = 'SoftIRQ'
             if i.raise_ts is not None:
-                raise_ts = " (raised at %s)" % \
+                raise_ts = ' (raised at %s)' % \
                            (common.ns_to_hour_nsec(i.raise_ts,
                                                    self._arg_multi_day,
                                                    self._arg_gmt))
             else:
-                raise_ts = ""
+                raise_ts = ''
             print(fmt.format(common.ns_to_hour_nsec(i.start_ts,
                                                     self._arg_multi_day,
                                                     self._arg_gmt),
                              common.ns_to_hour_nsec(i.stop_ts,
                                                     self._arg_multi_day,
                                                     self._arg_gmt),
-                             "%0.03f" % ((i.stop_ts - i.start_ts) / 1000),
-                             "%d" % i.cpu_id, irqtype, i.nr, name + raise_ts))
+                             '%0.03f' % ((i.stop_ts - i.start_ts) / 1000),
+                             '%d' % i.cpu_id, irqtype, i.nr, name + raise_ts))
 
     def print_irq_stats(self, dic, name_table, filter_list, header):
         header_output = 0
@@ -206,28 +206,28 @@ class IrqAnalysis(Command):
             stdev = self.compute_stdev(dic[i])
 
             # format string for the raise if present
-            if dic[i]["raise_count"] < 2:
-                raise_stats = " |"
+            if dic[i]['raise_count'] < 2:
+                raise_stats = ' |'
             else:
-                r_avg = dic[i]["raise_total"] / (dic[i]["raise_count"] * 1000)
-                raise_stats = " | {:>6} {:>12} {:>12} {:>12} {:>12}".format(
-                    dic[i]["raise_count"],
-                    "%0.03f" % (dic[i]["raise_min"] / 1000),
-                    "%0.03f" % r_avg,
-                    "%0.03f" % (dic[i]["raise_max"] / 1000),
-                    stdev["raise"])
+                r_avg = dic[i]['raise_total'] / (dic[i]['raise_count'] * 1000)
+                raise_stats = ' | {:>6} {:>12} {:>12} {:>12} {:>12}'.format(
+                    dic[i]['raise_count'],
+                    '%0.03f' % (dic[i]['raise_min'] / 1000),
+                    '%0.03f' % r_avg,
+                    '%0.03f' % (dic[i]['raise_max'] / 1000),
+                    stdev['raise'])
 
             # final output
-            if dic[i]["count"] == 0:
+            if dic[i]['count'] == 0:
                 continue
-            avg = "%0.03f" % (dic[i]["total"] / (dic[i]["count"] * 1000))
+            avg = '%0.03f' % (dic[i]['total'] / (dic[i]['count'] * 1000))
             format_str = '{:<3} {:<18} {:>5} {:>12} {:>12} {:>12} ' \
                          '{:>12} {:<60}'
-            s = format_str.format("%d:" % i, "<%s>" % name, dic[i]["count"],
-                                  "%0.03f" % (dic[i]["min"] / 1000),
-                                  "%s" % (avg),
-                                  "%0.03f" % (dic[i]["max"] / 1000),
-                                  "%s" % (stdev["duration"]),
+            s = format_str.format('%d:' % i, '<%s>' % name, dic[i]['count'],
+                                  '%0.03f' % (dic[i]['min'] / 1000),
+                                  '%s' % (avg),
+                                  '%0.03f' % (dic[i]['max'] / 1000),
+                                  '%s' % (stdev['duration']),
                                   raise_stats)
             if self._arg_stats and (self._arg_freq or header_output == 0):
                 print(header)
@@ -235,8 +235,8 @@ class IrqAnalysis(Command):
             if self._arg_stats:
                 print(s)
             if self._arg_freq:
-                self.irq_list_to_freq(dic[i], dic[i]["min"] / 1000,
-                                      dic[i]["max"] / 1000,
+                self.irq_list_to_freq(dic[i], dic[i]['min'] / 1000,
+                                      dic[i]['max'] / 1000,
                                       self._arg_freq_resolution, name, str(i))
 
     def _print_results(self, begin_ns, end_ns):
@@ -254,45 +254,45 @@ class IrqAnalysis(Command):
         print(date)
 
         if self._arg_irq_filter_list is not None:
-            header = ""
-            header += '{:<52} {:<12}\n'.format("Hard IRQ", "Duration (us)")
+            header = ''
+            header += '{:<52} {:<12}\n'.format('Hard IRQ', 'Duration (us)')
             header += '{:<22} {:<14} {:<12} {:<12} {:<10} ' \
-                      '{:<12}\n'.format("", "count", "min", "avg", "max",
-                                        "stdev")
-            header += ('-'*82 + "|")
-            self.print_irq_stats(self.state.interrupts["hard-irqs"],
-                                 self.state.interrupts["names"],
+                      '{:<12}\n'.format('', 'count', 'min', 'avg', 'max',
+                                        'stdev')
+            header += ('-'*82 + '|')
+            self.print_irq_stats(self.state.interrupts['hard-irqs'],
+                                 self.state.interrupts['names'],
                                  self._arg_irq_filter_list, header)
-            print("")
+            print('')
 
         if self._arg_softirq_filter_list is not None:
-            header = ""
-            header += '{:<52} {:<52} {:<12}\n'.format("Soft IRQ",
-                                                      "Duration (us)",
-                                                      "Raise latency (us)")
+            header = ''
+            header += '{:<52} {:<52} {:<12}\n'.format('Soft IRQ',
+                                                      'Duration (us)',
+                                                      'Raise latency (us)')
             header += '{:<22} {:<14} {:<12} {:<12} {:<10} {:<4} {:<3} {:<14} '\
                       '{:<12} {:<12} {:<10} ' \
-                      '{:<12}\n'.format("", "count", "min", "avg", "max",
-                                        "stdev", " |", "count", "min",
-                                        "avg", "max", "stdev")
-            header += '-' * 82 + "|" + '-' * 60
-            self.print_irq_stats(self.state.interrupts["soft-irqs"],
+                      '{:<12}\n'.format('', 'count', 'min', 'avg', 'max',
+                                        'stdev', ' |', 'count', 'min',
+                                        'avg', 'max', 'stdev')
+            header += '-' * 82 + '|' + '-' * 60
+            self.print_irq_stats(self.state.interrupts['soft-irqs'],
                                  sv.IRQ.soft_names,
                                  self._arg_softirq_filter_list,
                                  header)
-            print("")
+            print('')
 
     def _compute_stats(self):
         pass
 
     def _reset_total(self, start_ts):
-        self.state.interrupts["hard_count"] = 0
-        self.state.interrupts["soft_count"] = 0
-        self.state.interrupts["irq-list"] = []
-        for i in self.state.interrupts["hard-irqs"].keys():
-            self.state.interrupts["hard-irqs"][i] = sv.IRQ.init_irq_instance()
-        for i in self.state.interrupts["soft-irqs"].keys():
-            self.state.interrupts["soft-irqs"][i] = sv.IRQ.init_irq_instance()
+        self.state.interrupts['hard_count'] = 0
+        self.state.interrupts['soft_count'] = 0
+        self.state.interrupts['irq-list'] = []
+        for i in self.state.interrupts['hard-irqs'].keys():
+            self.state.interrupts['hard-irqs'][i] = sv.IRQ.init_irq_instance()
+        for i in self.state.interrupts['soft-irqs'].keys():
+            self.state.interrupts['soft-irqs'][i] = sv.IRQ.init_irq_instance()
 
     def _refresh(self, begin, end):
         self._compute_stats()

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -165,7 +165,7 @@ class IrqAnalysisCommand(Command):
                 return str(irq.id) in self._arg_irq_filter_list
             if self._arg_softirq_filter_list:
                 return False
-        else: # SoftIRQ
+        else:  # SoftIRQ
             if self._arg_softirq_filter_list:
                 return str(irq.id) in self._arg_softirq_filter_list
             if self._arg_irq_filter_list:
@@ -202,7 +202,8 @@ class IrqAnalysisCommand(Command):
                                                     self._arg_multi_day,
                                                     self._arg_gmt),
                              '%0.03f' % ((irq.stop_ts - irq.start_ts) / 1000),
-                             '%d' % irq.cpu_id, irqtype, irq.id, name + raise_ts))
+                             '%d' % irq.cpu_id, irqtype, irq.id,
+                             name + raise_ts))
 
     def _print_irq_stats(self, irq_stats, filter_list, header):
         header_printed = False
@@ -337,8 +338,8 @@ class IrqAnalysisCommand(Command):
             )
             header += '-' * 82 + '|' + '-' * 60
             self._print_irq_stats(self._analysis.softirq_stats,
-                                 self._arg_softirq_filter_list,
-                                 header)
+                                  self._arg_softirq_filter_list,
+                                  header)
 
     def _compute_stats(self):
         pass

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -30,7 +30,7 @@ from ascii_graph import Pyasciigraph
 import statistics
 
 
-class IrqAnalysis(Command):
+class IrqAnalysisCommand(Command):
     _VERSION = '0.1.0'
     _DESC = """The irq command."""
 
@@ -308,20 +308,20 @@ class IrqAnalysis(Command):
 # entry point
 def runstats():
     # create command
-    irqcmd = IrqAnalysis()
+    irqcmd = IrqAnalysisCommand()
     # execute command
     irqcmd.run_stats()
 
 
 def runlog():
     # create command
-    irqcmd = IrqAnalysis()
+    irqcmd = IrqAnalysisCommand()
     # execute command
     irqcmd.run_log()
 
 
 def runfreq():
     # create command
-    irqcmd = IrqAnalysis()
+    irqcmd = IrqAnalysisCommand()
     # execute command
     irqcmd.run_freq()

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -43,8 +43,8 @@ class IrqAnalysis(Command):
     def _validate_transform_args(self):
         # We need the min/max in the automaton to filter
         # at the source.
-        self._automaton.state.max = self._arg_max
-        self._automaton.state.min = self._arg_min
+        self.state.max = self._arg_max
+        self.state.min = self._arg_min
 
         self._arg_irq_filter_list = None
         self._arg_softirq_filter_list = None
@@ -95,8 +95,7 @@ class IrqAnalysis(Command):
         self.run(freq=True)
 
     def _create_analysis(self):
-        self._analysis = lttnganalyses.irq.IrqAnalysis(self._automaton.state)
-        self.state = self._automaton.state
+        self._analysis = lttnganalyses.irq.IrqAnalysis(self.state)
 
     def compute_stdev(self, irq):
         values = []
@@ -290,7 +289,6 @@ class IrqAnalysis(Command):
         pass
 
     def _reset_total(self, start_ts):
-        self.state = self._automaton.state
         self.state.interrupts["hard_count"] = 0
         self.state.interrupts["soft_count"] = 0
         self.state.interrupts["irq-list"] = []

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -141,29 +141,19 @@ class IrqAnalysisCommand(Command):
             print(line)
         print('')
 
-    # FIXME: there must be a way to make that more complicated/ugly
-    def filter_irq(self, i):
-        if i.irqclass == sv.IRQ.HARD_IRQ:
-            if self._arg_irq_filter_list is not None:
-                if len(self._arg_irq_filter_list) > 0 and \
-                        str(i.nr) not in self._arg_irq_filter_list:
-                    return False
-                else:
-                    return True
-            if self._arg_softirq_filter_list is not None and \
-                    len(self._arg_softirq_filter_list) > 0:
+    def filter_irq(self, irq):
+        if type(irq) is sv.HardIRQ:
+            if self._arg_irq_filter_list:
+                return str(irq.id) in self._arg_irq_filter_list
+            if self._arg_softirq_filter_list:
                 return False
-        else:
-            if self._arg_softirq_filter_list is not None:
-                if len(self._arg_softirq_filter_list) > 0 and \
-                        str(i.nr) not in self._arg_softirq_filter_list:
-                    return False
-                else:
-                    return True
-            if self._arg_irq_filter_list is not None and \
-                    len(self._arg_irq_filter_list) > 0:
+        else: # SoftIRQ
+            if self._arg_softirq_filter_list:
+                return str(irq.id) in self._arg_softirq_filter_list
+            if self._arg_irq_filter_list:
                 return False
-        raise Exception('WTF')
+
+        return True
 
     def log_irq(self):
         fmt = '[{:<18}, {:<18}] {:>15} {:>4}  {:<9} {:>4}  {:<22}'

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -45,14 +45,11 @@ class IrqAnalysisCommand(Command):
     def _validate_transform_args(self):
         self._arg_irq_filter_list = None
         self._arg_softirq_filter_list = None
+
         if self._args.irq:
             self._arg_irq_filter_list = self._args.irq.split(',')
         if self._args.softirq:
             self._arg_softirq_filter_list = self._args.softirq.split(',')
-        if self._arg_irq_filter_list is None and \
-                self._arg_softirq_filter_list is None:
-            self._arg_irq_filter_list = []
-            self._arg_softirq_filter_list = []
 
     def _default_args(self, stats, log, freq):
         if stats:
@@ -314,7 +311,8 @@ class IrqAnalysisCommand(Command):
     def _print_stats(self, begin_ns, end_ns):
         self._print_date(begin_ns, end_ns)
 
-        if self._arg_irq_filter_list is not None:
+        if self._arg_irq_filter_list is not None or \
+           self._arg_softirq_filter_list is None:
             header_format = '{:<52} {:<12}\n' \
                             '{:<22} {:<14} {:<12} {:<12} {:<10} {:<12}\n'
             header = header_format.format(
@@ -326,7 +324,8 @@ class IrqAnalysisCommand(Command):
                                   self._arg_irq_filter_list,
                                   header)
 
-        if self._arg_softirq_filter_list is not None:
+        if self._arg_softirq_filter_list is not None or \
+           self._arg_irq_filter_list is None:
             header_format = '{:<52} {:<52} {:<12}\n' \
                             '{:<22} {:<14} {:<12} {:<12} {:<10} {:<4} ' \
                             '{:<3} {:<14} {:<12} {:<12} {:<10} {:<12}\n'
@@ -357,9 +356,9 @@ class IrqAnalysisCommand(Command):
         self._reset_total(end)
 
     def _add_arguments(self, ap):
-        ap.add_argument('--irq', type=str, default=0,
+        ap.add_argument('--irq', type=str, default=None,
                         help='Show results only for the list of IRQ')
-        ap.add_argument('--softirq', type=str, default=0,
+        ap.add_argument('--softirq', type=str, default=None,
                         help='Show results only for the list of '
                              'SoftIRQ')
 

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -3,6 +3,7 @@
 # The MIT License (MIT)
 #
 # Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
+#               2015 - Antoine Busque <abusque@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -41,11 +42,6 @@ class IrqAnalysis(Command):
                          enable_stats_arg=True)
 
     def _validate_transform_args(self):
-        # We need the min/max in the automaton to filter
-        # at the source.
-        self.state.max = self._arg_max
-        self.state.min = self._arg_min
-
         self._arg_irq_filter_list = None
         self._arg_softirq_filter_list = None
         if self._args.irq:
@@ -95,7 +91,9 @@ class IrqAnalysis(Command):
         self.run(freq=True)
 
     def _create_analysis(self):
-        self._analysis = lttnganalyses.irq.IrqAnalysis(self.state)
+        self._analysis = lttnganalyses.irq.IrqAnalysis(self.state,
+                                                       self._arg_min,
+                                                       self._arg_max)
 
     def compute_stdev(self, irq):
         values = []

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -105,7 +105,7 @@ class IrqAnalysis(Command):
         for j in irq["list"]:
             delay = j.stop_ts - j.start_ts
             values.append(delay)
-            if j.raise_ts == -1:
+            if j.raise_ts is None:
                 continue
             # Raise latency (only for some softirqs)
             r_d = j.start_ts - j.raise_ts
@@ -182,7 +182,7 @@ class IrqAnalysis(Command):
             else:
                 name = sv.IRQ.soft_names[i.nr]
                 irqtype = "SoftIRQ"
-            if i.raise_ts != -1:
+            if i.raise_ts is not None:
                 raise_ts = " (raised at %s)" % \
                            (common.ns_to_hour_nsec(i.raise_ts,
                                                    self._arg_multi_day,

--- a/lttnganalysescli/lttnganalysescli/memtop.py
+++ b/lttnganalysescli/lttnganalysescli/memtop.py
@@ -69,16 +69,16 @@ class Memtop(Command):
             self.state.tids[tid].freed_pages = 0
 
     def _refresh(self, begin, end):
-        print('hey')
         self._compute_stats()
         self._print_results(begin, end)
         self._reset_total(end)
 
-    def filter_process(self, proc):
+    def _filter_process(self, proc):
         if self._arg_proc_list and proc.comm not in self._arg_proc_list:
             return False
         if self._arg_pid_list and str(proc.pid) not in self._arg_pid_list:
             return False
+
         return True
 
     def _print_results(self, begin_ns, end_ns):
@@ -100,7 +100,7 @@ class Memtop(Command):
         for tid in sorted(self.state.tids.values(),
                           key=operator.attrgetter('allocated_pages'),
                           reverse=True):
-            if not self.filter_process(tid):
+            if not self._filter_process(tid):
                 continue
 
             values.append(('%s (%d)' % (tid.comm, tid.tid),
@@ -122,7 +122,7 @@ class Memtop(Command):
         for tid in sorted(self.state.tids.values(),
                           key=operator.attrgetter('freed_pages'),
                           reverse=True):
-            if not self.filter_process(tid):
+            if not self._filter_process(tid):
                 continue
 
             values.append(('%s (%d)' % (tid.comm, tid.tid), tid.freed_pages))
@@ -140,7 +140,7 @@ class Memtop(Command):
         freed = 0
 
         for tid in self.state.tids.values():
-            if not self.filter_process(tid):
+            if not self._filter_process(tid):
                 continue
 
             alloc += tid.allocated_pages

--- a/lttnganalysescli/lttnganalysescli/memtop.py
+++ b/lttnganalysescli/lttnganalysescli/memtop.py
@@ -69,7 +69,7 @@ class Memtop(Command):
             self.state.tids[tid].freed_pages = 0
 
     def _refresh(self, begin, end):
-        print("hey")
+        print('hey')
         self._compute_stats()
         self._print_results(begin, end)
         self._reset_total(end)
@@ -103,15 +103,15 @@ class Memtop(Command):
             if not self.filter_process(tid):
                 continue
 
-            values.append(("%s (%d)" % (tid.comm, tid.tid),
+            values.append(('%s (%d)' % (tid.comm, tid.tid),
                           tid.allocated_pages))
 
             count += 1
             if self._arg_limit > 0 and count >= self._arg_limit:
                 break
 
-        for line in graph.graph("Per-TID Memory Allocations", values,
-                                unit=" pages"):
+        for line in graph.graph('Per-TID Memory Allocations', values,
+                                unit=' pages'):
             print(line)
 
     def _print_per_tid_freed(self):
@@ -125,14 +125,14 @@ class Memtop(Command):
             if not self.filter_process(tid):
                 continue
 
-            values.append(("%s (%d)" % (tid.comm, tid.tid), tid.freed_pages))
+            values.append(('%s (%d)' % (tid.comm, tid.tid), tid.freed_pages))
 
             count += 1
             if self._arg_limit > 0 and count >= self._arg_limit:
                 break
 
-        for line in graph.graph("Per-TID Memory Deallocation", values,
-                                unit=" pages"):
+        for line in graph.graph('Per-TID Memory Deallocation', values,
+                                unit=' pages'):
             print(line)
 
     def _print_total_alloc_freed(self):
@@ -146,7 +146,7 @@ class Memtop(Command):
             alloc += tid.allocated_pages
             freed += tid.freed_pages
 
-        print("\nTotal memory usage:\n- %d pages allocated\n- %d pages freed" %
+        print('\nTotal memory usage:\n- %d pages allocated\n- %d pages freed' %
              (alloc, freed))
 
     def _add_arguments(self, ap):

--- a/lttnganalysescli/lttnganalysescli/memtop.py
+++ b/lttnganalysescli/lttnganalysescli/memtop.py
@@ -147,7 +147,7 @@ class Memtop(Command):
             freed += tid.freed_pages
 
         print('\nTotal memory usage:\n- %d pages allocated\n- %d pages freed' %
-             (alloc, freed))
+              (alloc, freed))
 
     def _add_arguments(self, ap):
         # specific argument

--- a/lttnganalysescli/lttnganalysescli/memtop.py
+++ b/lttnganalysescli/lttnganalysescli/memtop.py
@@ -58,17 +58,15 @@ class Memtop(Command):
         self._close_trace()
 
     def _create_analysis(self):
-        self._analysis = lttnganalyses.memtop.Memtop(self._automaton.state)
+        self._analysis = lttnganalyses.memtop.Memtop(self.state)
 
     def _compute_stats(self):
         pass
 
     def _reset_total(self, start_ts):
-        self.state = self._automaton.state
         for tid in self.state.tids.keys():
             self.state.tids[tid].allocated_pages = 0
             self.state.tids[tid].freed_pages = 0
-        self.state = self._automaton.state
 
     def _refresh(self, begin, end):
         self._compute_stats()
@@ -87,7 +85,6 @@ class Memtop(Command):
         limit = self._arg_limit
         graph = Pyasciigraph()
         values = []
-        self.state = self._automaton.state
         alloc = 0
         freed = 0
         print('Timerange: [%s, %s]' % (

--- a/lttnganalysescli/lttnganalysescli/memtop.py
+++ b/lttnganalysescli/lttnganalysescli/memtop.py
@@ -53,7 +53,7 @@ class Memtop(Command):
         # process the results
         self._compute_stats()
         # print results
-        self._print_results(self.start_ns, self.trace_end_ts, final=1)
+        self._print_results(self.start_ns, self.trace_end_ts)
         # close the trace
         self._close_trace()
 
@@ -69,8 +69,9 @@ class Memtop(Command):
             self.state.tids[tid].freed_pages = 0
 
     def _refresh(self, begin, end):
+        print("hey")
         self._compute_stats()
-        self._print_results(begin, end, final=0)
+        self._print_results(begin, end)
         self._reset_total(end)
 
     def filter_process(self, proc):
@@ -80,7 +81,7 @@ class Memtop(Command):
             return False
         return True
 
-    def _print_results(self, begin_ns, end_ns, final=0):
+    def _print_results(self, begin_ns, end_ns):
         print('Timerange: [%s, %s]' % (
             common.ns_to_hour_nsec(begin_ns, gmt=self._arg_gmt,
                                    multi_day=True),

--- a/lttnganalysescli/lttnganalysescli/memtop.py
+++ b/lttnganalysescli/lttnganalysescli/memtop.py
@@ -68,8 +68,6 @@ class Memtop(Command):
         for tid in self.state.tids.keys():
             self.state.tids[tid].allocated_pages = 0
             self.state.tids[tid].freed_pages = 0
-        self.state.mm["allocated_pages"] = 0
-        self.state.mm["freed_pages"] = 0
         self.state = self._automaton.state
 
     def _refresh(self, begin, end):

--- a/lttnganalysescli/lttnganalysescli/progressbar.py
+++ b/lttnganalysescli/lttnganalysescli/progressbar.py
@@ -47,7 +47,7 @@ def getFolderSize(folder):
 
 
 def progressbar_setup(obj):
-    if hasattr(obj, "_arg_no_progress") and obj._arg_no_progress:
+    if hasattr(obj, '_arg_no_progress') and obj._arg_no_progress:
         obj.pbar = None
         return
 
@@ -60,15 +60,15 @@ def progressbar_setup(obj):
                                maxval=size/BYTES_PER_EVENT)
         obj.pbar.start()
     else:
-        print("Warning: progressbar module not available, "
-              "using --no-progress.", file=sys.stderr)
+        print('Warning: progressbar module not available, '
+              'using --no-progress.', file=sys.stderr)
         obj._arg_no_progress = True
         obj.pbar = None
     obj.event_count = 0
 
 
 def progressbar_update(obj):
-    if hasattr(obj, "_arg_no_progress") and \
+    if hasattr(obj, '_arg_no_progress') and \
             (obj._arg_no_progress or obj.pbar is None):
         return
     try:
@@ -79,6 +79,6 @@ def progressbar_update(obj):
 
 
 def progressbar_finish(obj):
-    if hasattr(obj, "_arg_no_progress") and obj._arg_no_progress:
+    if hasattr(obj, '_arg_no_progress') and obj._arg_no_progress:
         return
     obj.pbar.finish()

--- a/lttnganalysescli/lttnganalysescli/syscallstats.py
+++ b/lttnganalysescli/lttnganalysescli/syscallstats.py
@@ -88,8 +88,8 @@ class SyscallsAnalysis(Command):
                                    multi_day=True),
             common.ns_to_hour_nsec(end_ns, gmt=self._arg_gmt,
                                    multi_day=True)))
-        strformat = "{:<28} {:>14} {:>14} {:>14} {:>12} {:>10}  {:<14}"
-        print("Per-TID syscalls statistics (usec)")
+        strformat = '{:<28} {:>14} {:>14} {:>14} {:>12} {:>10}  {:<14}'
+        print('Per-TID syscalls statistics (usec)')
         for tid in sorted(self.state.tids.values(),
                           key=operator.attrgetter('total_syscalls'),
                           reverse=True):
@@ -97,9 +97,9 @@ class SyscallsAnalysis(Command):
                 continue
             if tid.total_syscalls == 0:
                 continue
-            print(strformat.format("%s (%d, tid = %d)" % (
+            print(strformat.format('%s (%d, tid = %d)' % (
                 tid.comm, tid.pid, tid.tid),
-                "Count", "Min", "Average", "Max", "Stdev", "Return values"))
+                'Count', 'Min', 'Average', 'Max', 'Stdev', 'Return values'))
             for syscall in sorted(tid.syscalls.values(),
                                   key=operator.attrgetter('count'),
                                   reverse=True):
@@ -108,7 +108,7 @@ class SyscallsAnalysis(Command):
                 for s in syscall.rq:
                     sysvalues.append(s.duration)
                     if s.ret >= 0:
-                        key = "success"
+                        key = 'success'
                     else:
                         try:
                             key = errno.errorcode[-s.ret]
@@ -119,26 +119,26 @@ class SyscallsAnalysis(Command):
                     else:
                         rets[key] = 1
                 if syscall.min is None:
-                    syscallmin = "?"
+                    syscallmin = '?'
                 else:
-                    syscallmin = "%0.03f" % (syscall.min / 1000)
-                syscallmax = "%0.03f" % (syscall.max / 1000)
-                syscallavg = "%0.03f" % \
+                    syscallmin = '%0.03f' % (syscall.min / 1000)
+                syscallmax = '%0.03f' % (syscall.max / 1000)
+                syscallavg = '%0.03f' % \
                     (syscall.total_duration/(syscall.count*1000))
                 if len(sysvalues) > 2:
-                    stdev = "%0.03f" % (statistics.stdev(sysvalues) / 1000)
+                    stdev = '%0.03f' % (statistics.stdev(sysvalues) / 1000)
                 else:
-                    stdev = "?"
-                name = syscall.name.replace("syscall_entry_", "")
-                name = name.replace("sys_", "")
-                print(strformat.format(" - " + name, syscall.count,
+                    stdev = '?'
+                name = syscall.name.replace('syscall_entry_', '')
+                name = name.replace('sys_', '')
+                print(strformat.format(' - ' + name, syscall.count,
                                        syscallmin, syscallavg, syscallmax,
                                        stdev, str(rets)))
-            print(strformat.format("Total:", tid.total_syscalls, "", "", "",
-                                   "", ""))
-            print("-" * 113)
+            print(strformat.format('Total:', tid.total_syscalls, '', '', '',
+                                   '', ''))
+            print('-' * 113)
 
-        print("\nTotal syscalls: %d" % (self.state.syscalls["total"]))
+        print('\nTotal syscalls: %d' % (self.state.syscalls['total']))
 
     def _reset_total(self, start_ts):
         pass

--- a/lttnganalysescli/lttnganalysescli/syscallstats.py
+++ b/lttnganalysescli/lttnganalysescli/syscallstats.py
@@ -65,11 +65,9 @@ class SyscallsAnalysis(Command):
         self._close_trace()
 
     def _create_analysis(self):
-        self._analysis = lttnganalyses.syscalls.SyscallsAnalysis(
-            self._automaton.state)
+        self._analysis = lttnganalyses.syscalls.SyscallsAnalysis(self.state)
 
     def _compute_stats(self):
-        self.state = self._automaton.state
         pass
 
     def _refresh(self, begin, end):

--- a/lttnganalysescli/lttnganalysescli/syscallstats.py
+++ b/lttnganalysescli/lttnganalysescli/syscallstats.py
@@ -60,7 +60,7 @@ class SyscallsAnalysis(Command):
         # process the results
         self._compute_stats()
         # print results
-        self._print_results(self.start_ns, self.trace_end_ts, final=1)
+        self._print_results(self.start_ns, self.trace_end_ts)
         # close the trace
         self._close_trace()
 
@@ -72,7 +72,7 @@ class SyscallsAnalysis(Command):
 
     def _refresh(self, begin, end):
         self._compute_stats()
-        self._print_results(begin, end, final=0)
+        self._print_results(begin, end)
         self._reset_total(end)
 
     def filter_process(self, proc):
@@ -82,7 +82,7 @@ class SyscallsAnalysis(Command):
             return False
         return True
 
-    def _print_results(self, begin_ns, end_ns, final=0):
+    def _print_results(self, begin_ns, end_ns):
         print('Timerange: [%s, %s]' % (
             common.ns_to_hour_nsec(begin_ns, gmt=self._arg_gmt,
                                    multi_day=True),

--- a/parser_generator.py
+++ b/parser_generator.py
@@ -124,7 +124,7 @@ def gen_parser(handle, fd, args):
             fd.write("\n        self.event_count[event.name] += 1\n")
             if not args.quiet:
                 fd.write("        print(\"%s }\" %% (%s))\n\n" %
-                        (fmt_str[0:-2], fmt_fields[0:-1]))
+                         (fmt_str[0:-2], fmt_fields[0:-1]))
 
 
 if __name__ == "__main__":

--- a/parser_generator.py
+++ b/parser_generator.py
@@ -130,7 +130,7 @@ def gen_parser(handle, fd, args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Trace parser generator')
     parser.add_argument('path', metavar="<path/to/trace>", help='Trace path')
-    parser.add_argument('-o', '--output', type=str, default=0,
+    parser.add_argument('-o', '--output', type=str,
                         metavar="<output-script-name>",
                         help='Output script name')
     parser.add_argument('-q', '--quiet', action="store_true",
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     if handle is None:
         sys.exit(1)
 
-    if args.output == 0:
+    if not args.output:
         output = "generated-parser.py"
     else:
         output = args.output


### PR DESCRIPTION
This pull request is rather large and unsightly, but in essence it does the following:

* Clean and Pythonify the codebase
* Refactor memtop analysis
* Rewrite the IRQ analysis

The clean-up and pythonification consisted in replacing C-like constructs by their Python equivalent. Usage of 0 and 1 as Boolean values has been eliminated, as were uses of -1 for invalid/none values. Style issues concerning inconsistent use of single and double quotes have also been fixed.

The refactor of memtop analysis removed obsolete or deprecated code, and simplified the remaining code by consolidating the memory state in a MemoryManagement class.

The core of this pull request, the IRQ analysis rewrite, is the first in a series of analysis rewrites which decouples the printing, analysis, and state tracking parts of the project. The tracking of the current system state is contained entirely within the linuxautomaton package, whereas all aggregation and post-processing of events have been moved to the IRQ analysis proper. The CLI also now handles only user-facing parts of the analysis, such as formatting/printing or refreshing the analysis.

Multiple bugs were also fixed throughout. The memtop analysis used to count the freed pages twice when displaying them, but this is fixed. Also, the mapping of softirq_raises and their corresponding entries has been greatly improved and now give more accurate stats by tracking virtually all raise latencies.