### PR TITLE
Decouple memtop

### DIFF
--- a/linuxautomaton/linuxautomaton/automaton.py
+++ b/linuxautomaton/linuxautomaton/automaton.py
@@ -43,14 +43,14 @@ class State:
         self.pending_syscalls = []
         self._notification_cbs = {}
 
-    def _register_notification_cbs(self, cbs):
+    def register_notification_cbs(self, cbs):
         for name in cbs:
             if name not in self._notification_cbs:
                 self._notification_cbs[name] = []
 
             self._notification_cbs[name].append(cbs[name])
 
-    def _send_notification_cb(self, name, **kwargs):
+    def send_notification_cb(self, name, **kwargs):
         if name in self._notification_cbs:
             for cb in self._notification_cbs[name]:
                 cb(**kwargs)

--- a/linuxautomaton/linuxautomaton/irq.py
+++ b/linuxautomaton/linuxautomaton/irq.py
@@ -54,8 +54,8 @@ class IrqStateProvider(sp.StateProvider):
         cpu.current_hard_irq = irq
 
         self.state.send_notification_cb('irq_handler_entry',
-                                         id=irq.id,
-                                         irq_name=event['name'])
+                                        id=irq.id,
+                                        irq_name=event['name'])
 
     def _process_irq_handler_exit(self, event):
         cpu = self._get_cpu(event['cpu_id'])
@@ -68,7 +68,7 @@ class IrqStateProvider(sp.StateProvider):
         cpu.current_hard_irq.ret = event['ret']
 
         self.state.send_notification_cb('irq_handler_exit',
-                                         hard_irq=cpu.current_hard_irq)
+                                        hard_irq=cpu.current_hard_irq)
         cpu.current_hard_irq = None
 
     # SoftIRQs
@@ -111,5 +111,5 @@ class IrqStateProvider(sp.StateProvider):
 
         cpu.current_softirqs[vec][0].stop_ts = event.timestamp
         self.state.send_notification_cb('softirq_exit',
-                                         softirq=cpu.current_softirqs[vec][0])
+                                        softirq=cpu.current_softirqs[vec][0])
         cpu.current_softirqs[vec].pop(0)

--- a/linuxautomaton/linuxautomaton/irq.py
+++ b/linuxautomaton/linuxautomaton/irq.py
@@ -53,7 +53,7 @@ class IrqStateProvider(sp.StateProvider):
         irq = sv.HardIRQ.new_from_irq_handler_entry(event)
         cpu.current_hard_irq = irq
 
-        self.state._send_notification_cb('irq_handler_entry',
+        self.state.send_notification_cb('irq_handler_entry',
                                          id=irq.id,
                                          irq_name=event['name'])
 
@@ -67,7 +67,7 @@ class IrqStateProvider(sp.StateProvider):
         cpu.current_hard_irq.stop_ts = event.timestamp
         cpu.current_hard_irq.ret = event['ret']
 
-        self.state._send_notification_cb('irq_handler_exit',
+        self.state.send_notification_cb('irq_handler_exit',
                                          hard_irq=cpu.current_hard_irq)
         cpu.current_hard_irq = None
 
@@ -110,6 +110,6 @@ class IrqStateProvider(sp.StateProvider):
             return
 
         cpu.current_softirqs[vec][0].stop_ts = event.timestamp
-        self.state._send_notification_cb('softirq_exit',
+        self.state.send_notification_cb('softirq_exit',
                                          softirq=cpu.current_softirqs[vec][0])
         cpu.current_softirqs[vec].pop(0)

--- a/linuxautomaton/linuxautomaton/mem.py
+++ b/linuxautomaton/linuxautomaton/mem.py
@@ -3,6 +3,7 @@
 # The MIT License (MIT)
 #
 # Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
+#               2015 - Antoine Busque <abusque@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -66,7 +67,7 @@ class MemStateProvider(sp.StateProvider):
         if current_process is None:
             return
 
-        current_process.allocated_pages += 1
+        self.state.send_notification_cb('tid_page_alloc', proc=current_process)
 
     def _process_mm_page_free(self, event):
         if self.state.mm.page_count == 0:
@@ -74,9 +75,8 @@ class MemStateProvider(sp.StateProvider):
 
         self.state.mm.page_count -= 1
 
-        # Track the number of pages freed by the currently executing process
         current_process = self._get_current_proc(event)
         if current_process is None:
             return
 
-        current_process.freed_pages += 1
+        self.state.send_notification_cb('tid_page_free', proc=current_process)

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -3,6 +3,7 @@
 # The MIT License (MIT)
 #
 # Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
+#               2015 - Antoine Busque <abusque@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -71,8 +72,6 @@ class Process():
         self.syscalls = {}
         self.perf = {}
         self.dirty = 0
-        self.allocated_pages = 0
-        self.freed_pages = 0
         self.total_syscalls = 0
         # array of IORequest objects for freq analysis later (block and
         # syscalls with no FD like sys_sync)

--- a/lttnganalyses/lttnganalyses/analysis.py
+++ b/lttnganalyses/lttnganalyses/analysis.py
@@ -27,6 +27,9 @@ class Analysis:
     def process_event(self, ev):
         raise NotImplementedError()
 
+    def reset(self):
+        raise NotImplementedError()
+
     def _register_cbs(self, cbs):
         self._cbs = cbs
 

--- a/lttnganalyses/lttnganalyses/cputop.py
+++ b/lttnganalyses/lttnganalyses/cputop.py
@@ -33,6 +33,9 @@ class Cputop(Analysis):
     def process_event(self, ev):
         self._ev_count += 1
 
+    def reset(self):
+        pass
+
     @property
     def event_count(self):
         return self._ev_count

--- a/lttnganalyses/lttnganalyses/irq.py
+++ b/lttnganalyses/lttnganalyses/irq.py
@@ -52,6 +52,13 @@ class IrqAnalysis(Analysis):
     def process_event(self, ev):
         pass
 
+    def reset(self):
+        self.irq_list = []
+        for id in self.hard_irq_stats:
+            self.hard_irq_stats[id].reset()
+        for id in self.softirq_stats:
+            self.softirq_stats[id].reset()
+
     def _process_irq_handler_entry(self, **kwargs):
         id = kwargs['id']
         name = kwargs['irq_name']

--- a/lttnganalyses/lttnganalyses/irq.py
+++ b/lttnganalyses/lttnganalyses/irq.py
@@ -34,7 +34,7 @@ class IrqAnalysis(Analysis):
         }
 
         self._state = state
-        self._state._register_notification_cbs(notification_cbs)
+        self._state.register_notification_cbs(notification_cbs)
         self._min_duration = min_duration
         self._max_duration = max_duration
         # µs to ns

--- a/lttnganalyses/lttnganalyses/memtop.py
+++ b/lttnganalyses/lttnganalyses/memtop.py
@@ -59,6 +59,7 @@ class Memtop(Analysis):
 
         self.tids[tid].freed_pages += 1
 
+
 class ProcessMemStats():
     def __init__(self, pid, tid, comm):
         self.pid = pid

--- a/lttnganalyses/lttnganalyses/memtop.py
+++ b/lttnganalyses/lttnganalyses/memtop.py
@@ -31,3 +31,6 @@ class Memtop(Analysis):
 
     def process_event(self, ev):
         pass
+
+    def reset(self):
+        pass

--- a/lttnganalyses/lttnganalyses/syscalls.py
+++ b/lttnganalyses/lttnganalyses/syscalls.py
@@ -31,3 +31,6 @@ class SyscallsAnalysis(Analysis):
 
     def process_event(self, ev):
         pass
+
+    def reset(self):
+        pass

--- a/lttnganalysescli/lttnganalysescli/command.py
+++ b/lttnganalysescli/lttnganalysescli/command.py
@@ -133,6 +133,14 @@ class Command:
             self.current_sec = event_sec
             self.start_ns = event.timestamp
 
+    def _print_date(self, begin_ns, end_ns):
+        date = 'Timerange: [%s, %s]' % (
+            common.ns_to_hour_nsec(begin_ns, gmt=self._arg_gmt,
+                                   multi_day=True),
+            common.ns_to_hour_nsec(end_ns, gmt=self._arg_gmt,
+                                   multi_day=True))
+        print(date)
+
     def _validate_transform_common_args(self, args):
         self._arg_path = args.path
 

--- a/lttnganalysescli/lttnganalysescli/cputop.py
+++ b/lttnganalysescli/lttnganalysescli/cputop.py
@@ -99,11 +99,7 @@ class Cputop(Command):
         total_ns = end_ns - begin_ns
         graph = Pyasciigraph()
         values = []
-        print('Timerange: [%s, %s]' % (
-            common.ns_to_hour_nsec(begin_ns, gmt=self._arg_gmt,
-                                   multi_day=True),
-            common.ns_to_hour_nsec(end_ns, gmt=self._arg_gmt,
-                                   multi_day=True)))
+        self._print_date(begin_ns, end_ns)
         for tid in sorted(self.state.tids.values(),
                           key=operator.attrgetter('cpu_ns'), reverse=True):
             if self._arg_proc_list and tid.comm not in self._arg_proc_list:

--- a/lttnganalysescli/lttnganalysescli/io.py
+++ b/lttnganalysescli/lttnganalysescli/io.py
@@ -751,11 +751,7 @@ class IoAnalysis(Command):
         self.iostats_output_disk()
 
     def _print_results(self, begin_ns, end_ns):
-        print('Timerange: [%s, %s]' % (
-            common.ns_to_hour_nsec(begin_ns, gmt=self._arg_gmt,
-                                   multi_day=True),
-            common.ns_to_hour_nsec(end_ns, gmt=self._arg_gmt,
-                                   multi_day=True)))
+        self._print_date(begin_ns, end_ns)
         if self._arg_usage:
             self.iotop_output()
         self.syscalls_stats = self.compute_syscalls_latency_stats(end_ns)

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -345,11 +345,7 @@ class IrqAnalysisCommand(Command):
         pass
 
     def _reset_total(self, start_ts):
-        self._analysis.irq_list = []
-        for id in self._analysis.hard_irq_stats:
-            self._analysis.hard_irq_stats[id].reset()
-        for id in self._analysis.softirq_stats:
-            self._analysis.softirq_stats[id].reset()
+        self._analysis.reset()
 
     def _refresh(self, begin, end):
         self._compute_stats()

--- a/lttnganalysescli/lttnganalysescli/irq.py
+++ b/lttnganalysescli/lttnganalysescli/irq.py
@@ -301,14 +301,6 @@ class IrqAnalysisCommand(Command):
         if self._arg_log:
             self._print_irq_log()
 
-    def _print_date(self, begin_ns, end_ns):
-        date = 'Timerange: [%s, %s]' % (
-            common.ns_to_hour_nsec(begin_ns, gmt=self._arg_gmt,
-                                   multi_day=True),
-            common.ns_to_hour_nsec(end_ns, gmt=self._arg_gmt,
-                                   multi_day=True))
-        print(date)
-
     def _print_stats(self, begin_ns, end_ns):
         self._print_date(begin_ns, end_ns)
 

--- a/lttnganalysescli/lttnganalysescli/memtop.py
+++ b/lttnganalysescli/lttnganalysescli/memtop.py
@@ -3,6 +3,7 @@
 # The MIT License (MIT)
 #
 # Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
+#               2015 - Antoine Busque <abusque@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -64,9 +65,7 @@ class Memtop(Command):
         pass
 
     def _reset_total(self, start_ts):
-        for tid in self.state.tids.keys():
-            self.state.tids[tid].allocated_pages = 0
-            self.state.tids[tid].freed_pages = 0
+        self._analysis.reset()
 
     def _refresh(self, begin, end):
         self._compute_stats()
@@ -92,7 +91,7 @@ class Memtop(Command):
         values = []
         count = 0
 
-        for tid in sorted(self.state.tids.values(),
+        for tid in sorted(self._analysis.tids.values(),
                           key=operator.attrgetter('allocated_pages'),
                           reverse=True):
             if not self._filter_process(tid):
@@ -114,7 +113,7 @@ class Memtop(Command):
         values = []
         count = 0
 
-        for tid in sorted(self.state.tids.values(),
+        for tid in sorted(self._analysis.tids.values(),
                           key=operator.attrgetter('freed_pages'),
                           reverse=True):
             if not self._filter_process(tid):
@@ -134,7 +133,7 @@ class Memtop(Command):
         alloc = 0
         freed = 0
 
-        for tid in self.state.tids.values():
+        for tid in self._analysis.tids.values():
             if not self._filter_process(tid):
                 continue
 

--- a/lttnganalysescli/lttnganalysescli/memtop.py
+++ b/lttnganalysescli/lttnganalysescli/memtop.py
@@ -82,12 +82,7 @@ class Memtop(Command):
         return True
 
     def _print_results(self, begin_ns, end_ns):
-        print('Timerange: [%s, %s]' % (
-            common.ns_to_hour_nsec(begin_ns, gmt=self._arg_gmt,
-                                   multi_day=True),
-            common.ns_to_hour_nsec(end_ns, gmt=self._arg_gmt,
-                                   multi_day=True)))
-
+        self._print_date(begin_ns, end_ns)
         self._print_per_tid_alloc()
         self._print_per_tid_freed()
         self._print_total_alloc_freed()

--- a/lttnganalysescli/lttnganalysescli/syscallstats.py
+++ b/lttnganalysescli/lttnganalysescli/syscallstats.py
@@ -83,11 +83,7 @@ class SyscallsAnalysis(Command):
         return True
 
     def _print_results(self, begin_ns, end_ns):
-        print('Timerange: [%s, %s]' % (
-            common.ns_to_hour_nsec(begin_ns, gmt=self._arg_gmt,
-                                   multi_day=True),
-            common.ns_to_hour_nsec(end_ns, gmt=self._arg_gmt,
-                                   multi_day=True)))
+        self._print_date(begin_ns, end_ns)
         strformat = '{:<28} {:>14} {:>14} {:>14} {:>12} {:>10}  {:<14}'
         print('Per-TID syscalls statistics (usec)')
         for tid in sorted(self.state.tids.values(),


### PR DESCRIPTION
This pull request decouples the analysis part of memtop from the corresponding state tracking. It also adds `reset` and `_print_date` methods to the base `Analysis` and `Command` classes respectively to simplify the code.