### PR TITLE
Decouple analysis and state for cputop

### DIFF
--- a/linuxautomaton/linuxautomaton/sched.py
+++ b/linuxautomaton/linuxautomaton/sched.py
@@ -3,6 +3,7 @@
 # The MIT License (MIT)
 #
 # Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
+#               2015 - Antoine Busque <abusque@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +24,6 @@
 # SOFTWARE.
 
 from linuxautomaton import sp, sv
-from babeltrace import CTFScope
 
 
 class SchedStateProvider(sp.StateProvider):
@@ -82,21 +82,6 @@ class SchedStateProvider(sp.StateProvider):
             p = self.state.tids[prev_tid]
             if p.last_sched is not None:
                 p.cpu_ns += (ts - p.last_sched)
-            # perf PMU counters checks
-            for context in event.field_list_with_scope(
-                    CTFScope.STREAM_EVENT_CONTEXT):
-                if context.startswith('perf_'):
-                    if context not in c.perf.keys():
-                        c.perf[context] = event[context]
-                    # add the difference between the last known value
-                    # for this counter on the current sv.CPU
-                    diff = event[context] - c.perf[context]
-                    if context not in p.perf.keys():
-                        p.perf[context] = diff
-                    else:
-                        p.perf[context] += diff
-                    if diff > 0:
-                        ret[context] = diff
 
         # exclude swapper process
         if next_tid == 0:

--- a/linuxautomaton/linuxautomaton/sched.py
+++ b/linuxautomaton/linuxautomaton/sched.py
@@ -42,140 +42,82 @@ class SchedStateProvider(sp.StateProvider):
     def process_event(self, ev):
         self._process_event_cb(ev)
 
-    def sched_switch_per_cpu(self, cpu_id, ts, next_tid, event):
-        """Compute per-cpu usage"""
-        if cpu_id in self.state.cpus:
-            c = self.state.cpus[cpu_id]
-            if c.start_task_ns != 0:
-                c.cpu_ns += ts - c.start_task_ns
-            # exclude swapper process
-            if next_tid != 0:
-                c.start_task_ns = ts
-                c.current_tid = next_tid
-            else:
-                c.start_task_ns = 0
-                c.current_tid = None
+    def _fix_process(self, tid, pid, comm):
+        """Fix a process' pid and comm if it exists, create it otherwise"""
+        if tid not in self.state.tids:
+            proc = sv.Process(tid, pid, comm)
+            self.state.tids[tid] = proc
         else:
-            self.add_cpu(cpu_id, ts, next_tid)
-        for context in event.keys():
-            if context.startswith('perf_'):
-                c.perf[context] = event[context]
+            proc = self.state.tids[tid]
+            proc.pid = pid
+            proc.comm = comm
 
-    def add_cpu(self, cpu_id, ts, next_tid):
-        c = sv.CPU(cpu_id)
-        c.current_tid = next_tid
-        # when we schedule a real task (not swapper)
-        c.start_task_ns = ts
-        # first activity on the sv.CPU
-        self.state.cpus[cpu_id] = c
-        self.state.cpus[cpu_id].total_per_cpu_pc_list = []
+    def _sched_switch_per_cpu(self, cpu_id, next_tid):
+        if cpu_id not in self.state.cpus:
+            self.state.cpus[cpu_id] = sv.CPU(cpu_id)
 
-    def sched_switch_per_tid(self, ts, prev_tid, next_tid,
-                             next_comm, cpu_id, event, ret):
-        """Compute per-tid usage"""
-        # if we don't know yet the sv.CPU, skip this
-        if cpu_id not in self.state.cpus.keys():
-            self.add_cpu(cpu_id, ts, next_tid)
-        c = self.state.cpus[cpu_id]
-        # per-tid usage
-        if prev_tid in self.state.tids:
-            p = self.state.tids[prev_tid]
-            if p.last_sched is not None:
-                p.cpu_ns += (ts - p.last_sched)
-
+        cpu = self.state.cpus[cpu_id]
         # exclude swapper process
         if next_tid == 0:
-            return ret
+            cpu.current_tid = None
+        else:
+            cpu.current_tid = next_tid
+
+    def _sched_switch_per_tid(self, next_tid, next_comm, prev_tid):
+        # exclude swapper process
+        if next_tid == 0:
+            return
 
         if next_tid not in self.state.tids:
-            p = sv.Process()
-            p.tid = next_tid
-            p.comm = next_comm
-            self.state.tids[next_tid] = p
-        else:
-            p = self.state.tids[next_tid]
-            p.comm = next_comm
-        p.last_sched = ts
-        for q in c.wakeup_queue:
-            if q['task'] == p:
-                ret['sched_latency'] = ts - q['ts']
-                ret['next_tid'] = next_tid
-                c.wakeup_queue.remove(q)
-        return ret
+            self.state.tids[next_tid] = sv.Process(tid=next_tid)
+
+        next_proc = self.state.tids[next_tid]
+        next_proc.comm = next_comm
+        next_proc.prev_tid = prev_tid
 
     def _process_sched_switch(self, event):
-        """Handle sched_switch event, returns a dict of changed values"""
-        prev_tid = event['prev_tid']
-        next_comm = event['next_comm']
-        next_tid = event['next_tid']
+        timestamp = event.timestamp
         cpu_id = event['cpu_id']
-        ret = {}
+        next_tid = event['next_tid']
+        next_comm = event['next_comm']
+        prev_tid = event['prev_tid']
 
-        self.sched_switch_per_tid(event.timestamp, prev_tid,
-                                  next_tid, next_comm,
-                                  cpu_id, event, ret)
-        # because of perf events check, we need to do the sv.CPU analysis after
-        # the per-tid analysis
-        self.sched_switch_per_cpu(cpu_id, event.timestamp, next_tid, event)
-        if next_tid > 0:
-            self.state.tids[next_tid].prev_tid = prev_tid
+        self._sched_switch_per_cpu(cpu_id, next_tid)
+        self._sched_switch_per_tid(next_tid, next_comm, prev_tid)
 
-        return ret
+        self.state.send_notification_cb('sched_switch_per_cpu',
+                                        timestamp=timestamp,
+                                        cpu_id=cpu_id,
+                                        next_tid=next_tid)
+        self.state.send_notification_cb('sched_switch_per_tid',
+                                        timestamp=timestamp,
+                                        prev_tid=prev_tid,
+                                        next_tid=next_tid,
+                                        next_comm=next_comm)
 
     def _process_sched_migrate_task(self, event):
         tid = event['tid']
         if tid not in self.state.tids:
-            p = sv.Process()
-            p.tid = tid
-            p.comm = event['comm']
-            self.state.tids[tid] = p
+            proc = sv.Process()
+            proc.tid = tid
+            proc.comm = event['comm']
+            self.state.tids[tid] = proc
         else:
-            p = self.state.tids[tid]
-        p.migrate_count += 1
+            proc = self.state.tids[tid]
+
+        self.state.send_notification_cb('sched_migrate_task', proc=proc)
 
     def _process_sched_wakeup(self, event):
-        """Stores the sched_wakeup infos to compute scheduling latencies"""
         target_cpu = event['target_cpu']
         tid = event['tid']
-        if target_cpu not in self.state.cpus.keys():
-            c = sv.CPU(target_cpu)
-            self.state.cpus[target_cpu] = c
-        else:
-            c = self.state.cpus[target_cpu]
+
+        if target_cpu not in self.state.cpus:
+            self.state.cpus[target_cpu] = sv.CPU(target_cpu)
 
         if tid not in self.state.tids:
-            p = sv.Process()
-            p.tid = tid
-            self.state.tids[tid] = p
-        else:
-            p = self.state.tids[tid]
-        c.wakeup_queue.append({'ts': event.timestamp, 'task': p})
-
-    def fix_process(self, name, tid, pid):
-        if tid not in self.state.tids:
-            p = sv.Process()
-            p.tid = tid
-            self.state.tids[tid] = p
-        else:
-            p = self.state.tids[tid]
-        p.pid = pid
-        p.comm = name
-
-        if pid not in self.state.tids:
-            p = sv.Process()
-            p.tid = pid
-            self.state.tids[pid] = p
-        else:
-            p = self.state.tids[pid]
-        p.pid = pid
-        p.comm = name
-
-    def dup_fd(self, fd):
-        f = sv.FD()
-        f.filename = fd.filename
-        f.fd = fd.fd
-        f.fdtype = fd.fdtype
-        return f
+            proc = sv.Process()
+            proc.tid = tid
+            self.state.tids[tid] = proc
 
     def _process_sched_process_fork(self, event):
         child_tid = event['child_tid']
@@ -184,33 +126,36 @@ class SchedStateProvider(sp.StateProvider):
         parent_pid = event['parent_pid']
         parent_tid = event['parent_pid']
         parent_comm = event['parent_comm']
-        f = sv.Process()
-        f.tid = child_tid
-        f.pid = child_pid
-        f.comm = child_comm
 
-        # make sure the parent exists
-        self.fix_process(parent_comm, parent_tid, parent_pid)
-        p = self.state.tids[parent_pid]
-        for fd in p.fds.keys():
-            f.fds[fd] = self.dup_fd(p.fds[fd])
-            f.fds[fd].parent = parent_pid
+        child_proc = sv.Process(child_tid, child_pid, child_comm)
 
-        self.state.tids[child_tid] = f
+        self._fix_process(parent_tid, parent_pid, parent_comm)
+        parent_proc = self.state.tids[parent_pid]
+
+        for fd in parent_proc.fds:
+            old_fd = parent_proc.fds[fd]
+            child_proc.fds[fd] = sv.FD.new_from_fd(old_fd)
+            child_proc.fds[fd].parent = parent_pid
+
+        self.state.tids[child_tid] = child_proc
 
     def _process_sched_process_exec(self, event):
         tid = event['tid']
+
         if tid not in self.state.tids:
-            p = sv.Process()
-            p.tid = tid
-            self.state.tids[tid] = p
+            proc = sv.Process()
+            proc.tid = tid
+            self.state.tids[tid] = proc
         else:
-            p = self.state.tids[tid]
-        if 'procname' in event.keys():
-            p.comm = event['procname']
+            proc = self.state.tids[tid]
+
+        # Use LTTng procname context if available
+        if 'procname' in event:
+            proc.comm = event['procname']
+
         toremove = []
-        for fd in p.fds.keys():
-            if p.fds[fd].cloexec == 1:
+        for fd in proc.fds:
+            if proc.fds[fd].cloexec:
                 toremove.append(fd)
         for fd in toremove:
-            p.fds.pop(fd, None)
+            del proc.fds[fd]

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -62,8 +62,6 @@ class Process():
         # total I/O read/write
         self.read = 0
         self.write = 0
-        # last TS where the process was scheduled in
-        self.last_sched = None
         # the process scheduled before this one
         self.prev_tid = None
         # indexed by syscall_name

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -178,7 +178,19 @@ class FD():
         self.fdtype = FDType.unknown
         # if FD was inherited, parent PID
         self.parent = None
+        self.cloexec = False
         self.init_counts()
+
+    @classmethod
+    def new_from_fd(cls, fd):
+        new_fd = cls()
+        new_fd.filename = fd.filename
+        new_fd.fd = fd.fd
+        new_fd.family = fd.family
+        new_fd.fdtype = fd.fdtype
+        new_fd.parent = fd.parent
+        new_fd.cloexec = fd.cloexec
+        return new_fd
 
     def init_counts(self):
         # network read/write
@@ -195,7 +207,6 @@ class FD():
         self.write = 0
         self.open = 0
         self.close = 0
-        self.cloexec = 0
         # array of syscall IORequest objects for freq analysis later
         self.iorequests = []
 

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -32,10 +32,10 @@ class StateVariable:
 
 
 class Process():
-    def __init__(self):
-        self.tid = None
-        self.pid = None
-        self.comm = ''
+    def __init__(self, tid=None, pid=None, comm=''):
+        self.tid = tid
+        self.pid = pid
+        self.comm = comm
         # indexed by fd
         self.fds = {}
         # indexed by filename
@@ -48,7 +48,6 @@ class Process():
 
     def init_counts(self):
         self.cpu_ns = 0
-        self.migrate_count = 0
         # network read/write
         self.net_read = 0
         self.net_write = 0
@@ -70,7 +69,6 @@ class Process():
         self.prev_tid = None
         # indexed by syscall_name
         self.syscalls = {}
-        self.perf = {}
         self.dirty = 0
         self.total_syscalls = 0
         # array of IORequest objects for freq analysis later (block and
@@ -95,16 +93,12 @@ class Process():
 class CPU():
     def __init__(self, cpu_id):
         self.cpu_id = cpu_id
-        self.cpu_ns = 0
         self.current_tid = None
         self.current_hard_irq = None
         # softirqs use a dict because multiple ones can be raised before
         # handling. They are indexed by vec, and each entry is a list,
         # ordered chronologically
         self.current_softirqs = {}
-        self.start_task_ns = 0
-        self.perf = {}
-        self.wakeup_queue = []
 
 
 class MemoryManagement():
@@ -366,6 +360,3 @@ class SyscallConsts():
     # generic names assigned to special FDs, don't try to match these in the
     # closed_fds dict
     GENERIC_NAMES = ['unknown', 'socket']
-
-    def __init__():
-        pass

--- a/linuxautomaton/linuxautomaton/sv.py
+++ b/linuxautomaton/linuxautomaton/sv.py
@@ -47,7 +47,6 @@ class Process():
         self.init_counts()
 
     def init_counts(self):
-        self.cpu_ns = 0
         # network read/write
         self.net_read = 0
         self.net_write = 0

--- a/linuxautomaton/linuxautomaton/syscalls.py
+++ b/linuxautomaton/linuxautomaton/syscalls.py
@@ -30,7 +30,11 @@ from babeltrace import CTFScope
 class SyscallsStateProvider(sp.StateProvider):
     def __init__(self, state):
         self.state = state
-        self.state.syscalls['total'] = 0
+        self.cpus = state.cpus
+        self.tids = state.tids
+        self.syscalls = state.syscalls
+        self.pending_syscalls = state.pending_syscalls
+        self.syscalls['total'] = 0
         cbs = {
             'syscall_entry': self._process_syscall_entry,
             'syscall_exit': self._process_syscall_exit,

--- a/linuxautomaton/linuxautomaton/syscalls.py
+++ b/linuxautomaton/linuxautomaton/syscalls.py
@@ -108,7 +108,7 @@ class SyscallsStateProvider(sp.StateProvider):
         if name in sv.SyscallConsts.DISK_OPEN_SYSCALLS:
             current_syscall['filename'] = event['filename']
             if event['flags'] & common.O_CLOEXEC == common.O_CLOEXEC:
-                current_syscall['cloexec'] = 1
+                current_syscall['cloexec'] = True
         elif name in ['sys_accept', 'syscall_entry_accept',
                       'sys_accept4', 'syscall_entry_accept4']:
             if 'family' in event.keys() and event['family'] == socket.AF_INET:
@@ -340,7 +340,7 @@ class SyscallsStateProvider(sp.StateProvider):
         else:
             return
         if 'cloexec' in current_syscall.keys():
-            fd.cloexec = 1
+            fd.cloexec = True
         t.fds[fd.fd] = fd
 
         t.track_chrono_fd(fd.fd, fd.filename, fd.fdtype, event.timestamp)

--- a/linuxautomaton/linuxautomaton/syscalls.py
+++ b/linuxautomaton/linuxautomaton/syscalls.py
@@ -30,11 +30,7 @@ from babeltrace import CTFScope
 class SyscallsStateProvider(sp.StateProvider):
     def __init__(self, state):
         self.state = state
-        self.cpus = state.cpus
-        self.tids = state.tids
-        self.syscalls = state.syscalls
-        self.pending_syscalls = state.pending_syscalls
-        self.syscalls['total'] = 0
+        self.state.syscalls['total'] = 0
         cbs = {
             'syscall_entry': self._process_syscall_entry,
             'syscall_exit': self._process_syscall_exit,

--- a/lttnganalyses/lttnganalyses/cputop.py
+++ b/lttnganalyses/lttnganalyses/cputop.py
@@ -3,6 +3,7 @@
 # The MIT License (MIT)
 #
 # Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
+#               2015 - Antoine Busque <abusque@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,15 +28,151 @@ from .analysis import Analysis
 
 class Cputop(Analysis):
     def __init__(self, state):
+        notification_cbs = {
+            'sched_migrate_task': self._process_sched_migrate_task,
+            'sched_switch_per_cpu': self._process_sched_switch_per_cpu,
+            'sched_switch_per_tid': self._process_sched_switch_per_tid
+        }
+
         self._state = state
+        self._state.register_notification_cbs(notification_cbs)
         self._ev_count = 0
+        self.cpus = {}
+        self.tids = {}
 
     def process_event(self, ev):
         self._ev_count += 1
 
-    def reset(self):
-        pass
+    def reset(self, timestamp):
+        for cpu_id in self.cpus:
+            self.cpus[cpu_id].reset(timestamp)
+
+        for tid in self.tids:
+            self.tids[tid].reset(timestamp)
+
+    def compute_stats(self, start_ts, end_ts):
+        """Compute usage stats relative to a certain time range
+
+        For each CPU and process tracked by the analysis, we set its
+        usage_percent attribute, which represents the percentage of
+        usage time for the given CPU or process relative to the full
+        duration of the time range. Do note that we need to know the
+        timestamps and not just the duration, because if a CPU or a
+        process is currently busy, we use the end timestamp to add
+        the partial results of the currently running task to the usage
+        stats.
+
+        Args:
+        start_ts (int): start of time range (nanoseconds from unix
+        epoch)
+        end_ts (int): end of time range (nanoseconds from unix epoch)
+        """
+        duration = end_ts - start_ts
+
+        for cpu_id in self.cpus:
+            cpu = self.cpus[cpu_id]
+            if cpu.current_task_start_ts is not None:
+                cpu.total_usage_time += end_ts - cpu.current_task_start_ts
+
+            cpu.compute_stats(duration)
+
+        for tid in self.tids:
+            proc = self.tids[tid]
+            if proc.last_sched_ts is not None:
+                proc.total_cpu_time += end_ts - proc.last_sched_ts
+
+            proc.compute_stats(duration)
+
+    def _process_sched_switch_per_cpu(self, **kwargs):
+        timestamp = kwargs['timestamp']
+        cpu_id = kwargs['cpu_id']
+        next_tid = kwargs['next_tid']
+
+        if cpu_id not in self.cpus:
+            self.cpus[cpu_id] = CpuUsageStats(cpu_id)
+
+        cpu = self.cpus[cpu_id]
+        if cpu.current_task_start_ts is not None:
+            cpu.total_usage_time += timestamp - cpu.current_task_start_ts
+
+        if next_tid == 0:
+            cpu.current_task_start_ts = None
+        else:
+            cpu.current_task_start_ts = timestamp
+
+    def _process_sched_switch_per_tid(self, **kwargs):
+        timestamp = kwargs['timestamp']
+        prev_tid = kwargs['prev_tid']
+        next_tid = kwargs['next_tid']
+        next_comm = kwargs['next_comm']
+
+        if prev_tid in self.tids:
+            prev_proc = self.tids[prev_tid]
+            if prev_proc.last_sched_ts is not None:
+                prev_proc.total_cpu_time += timestamp - prev_proc.last_sched_ts
+                prev_proc.last_sched_ts = None
+
+        # Don't account for swapper process
+        if next_tid == 0:
+            return
+
+        if next_tid not in self.tids:
+            self.tids[next_tid] = ProcessCpuStats(next_tid, next_comm)
+
+        next_proc = self.tids[next_tid]
+        next_proc.last_sched_ts = timestamp
+
+    def _process_sched_migrate_task(self, **kwargs):
+        proc = kwargs['proc']
+        tid = proc.tid
+        if tid not in self.tids:
+            self.tids[tid] = ProcessCpuStats.new_from_process(proc)
+
+        self.tids[tid].migrate_count += 1
 
     @property
     def event_count(self):
         return self._ev_count
+
+
+class CpuUsageStats():
+    def __init__(self, cpu_id):
+        self.cpu_id = cpu_id
+        # Usage time and start timestamp are in nanoseconds (ns)
+        self.total_usage_time = 0
+        self.current_task_start_ts = None
+        self.usage_percent = None
+
+    def compute_stats(self, duration):
+        self.usage_percent = self.total_usage_time * 100 / duration
+
+    def reset(self, timestamp):
+        self.total_usage_time = 0
+        self.usage_percent = None
+        if self.current_task_start_ts is not None:
+            self.current_task_start_ts = timestamp
+
+
+class ProcessCpuStats():
+    def __init__(self, tid, comm):
+        self.tid = tid
+        self.comm = comm
+        # CPU Time and timestamp in nanoseconds (ns)
+        self.total_cpu_time = 0
+        self.last_sched_ts = None
+        self.migrate_count = 0
+        self.usage_percent = None
+
+    @classmethod
+    def new_from_process(cls, proc):
+        return cls(proc.tid, proc.comm)
+
+    def compute_stats(self, duration):
+        self.usage_percent = self.total_cpu_time * 100 / duration
+
+    def reset(self, timestamp):
+        self.total_cpu_time = 0
+        self.migrate_count = 0
+        self.usage_percent = None
+        if self.last_sched_ts is not None:
+            self.last_sched_ts = timestamp

--- a/lttnganalysescli/lttnganalysescli/cputop.py
+++ b/lttnganalysescli/lttnganalysescli/cputop.py
@@ -3,6 +3,7 @@
 # The MIT License (MIT)
 #
 # Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
+#               2015 - Antoine Busque <abusque@efficios.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +25,6 @@
 
 from .command import Command
 import lttnganalyses.cputop
-from linuxautomaton import common
 from ascii_graph import Pyasciigraph
 import operator
 
@@ -61,74 +61,81 @@ class Cputop(Command):
         self._analysis = lttnganalyses.cputop.Cputop(self.state)
 
     def _compute_stats(self):
-        for cpu in self.state.cpus.keys():
-            current_cpu = self.state.cpus[cpu]
-            total_ns = self.end_ns - self.start_ns
-            if current_cpu.start_task_ns != 0:
-                current_cpu.cpu_ns += self.end_ns - current_cpu.start_task_ns
-            cpu_total_ns = current_cpu.cpu_ns
-            current_cpu.cpu_pc = (cpu_total_ns * 100)/total_ns
-            if current_cpu.current_tid is not None:
-                self.state.tids[current_cpu.current_tid].cpu_ns += \
-                    self.end_ns - current_cpu.start_task_ns
+        self._analysis.compute_stats(self.start_ns, self.end_ns)
 
     def _reset_total(self, start_ts):
-        for cpu in self.state.cpus.keys():
-            current_cpu = self.state.cpus[cpu]
-            current_cpu.cpu_ns = 0
-            if current_cpu.start_task_ns != 0:
-                current_cpu.start_task_ns = start_ts
-            if current_cpu.current_tid is not None:
-                self.state.tids[current_cpu.current_tid].last_sched = start_ts
-        for tid in self.state.tids.keys():
-            self.state.tids[tid].cpu_ns = 0
-            self.state.tids[tid].migrate_count = 0
-            self.state.tids[tid].read = 0
-            self.state.tids[tid].write = 0
-            for syscall in self.state.tids[tid].syscalls.keys():
-                self.state.tids[tid].syscalls[syscall].count = 0
+        self._analysis.reset(start_ts)
 
     def _refresh(self, begin, end):
         self._compute_stats()
         self._print_results(begin, end)
         self._reset_total(end)
 
+    def _filter_process(self, proc):
+        # Exclude swapper
+        if proc.tid == 0:
+            return False
+
+        if self._arg_proc_list and proc.comm not in self._arg_proc_list:
+            return False
+
+        return True
+
     def _print_results(self, begin_ns, end_ns):
+        self._print_date(begin_ns, end_ns)
+        self._print_per_tid_usage()
+        self._print_per_cpu_usage()
+        self._print_total_cpu_usage()
+
+    def _print_per_tid_usage(self):
         count = 0
         limit = self._arg_limit
-        total_ns = end_ns - begin_ns
         graph = Pyasciigraph()
         values = []
-        self._print_date(begin_ns, end_ns)
-        for tid in sorted(self.state.tids.values(),
-                          key=operator.attrgetter('cpu_ns'), reverse=True):
-            if self._arg_proc_list and tid.comm not in self._arg_proc_list:
+
+        for tid in sorted(self._analysis.tids.values(),
+                          key=operator.attrgetter('usage_percent'),
+                          reverse=True):
+            if not self._filter_process(tid):
                 continue
-            if tid.tid == 0:
-                continue
-            pc = float('%0.02f' % ((tid.cpu_ns * 100) / total_ns))
+
+            output_str = '%s (%d)' % (tid.comm, tid.tid)
             if tid.migrate_count > 0:
-                migrations = ', %d migrations' % (tid.migrate_count)
-            else:
-                migrations = ''
-            values.append(('%s (%d)%s' % (tid.comm, tid.tid, migrations), pc))
-            count = count + 1
+                output_str += ', %d migrations' % (tid.migrate_count)
+
+            values.append((output_str, tid.usage_percent))
+
+            count += 1
             if limit > 0 and count >= limit:
                 break
+
         for line in graph.graph('Per-TID CPU Usage', values, unit=' %'):
             print(line)
 
+    def _print_per_cpu_usage(self):
+        graph = Pyasciigraph()
         values = []
-        total_cpu_pc = 0
-        for cpu in sorted(self.state.cpus.values(),
-                          key=operator.attrgetter('cpu_ns'), reverse=True):
-            cpu_pc = float('%0.02f' % cpu.cpu_pc)
-            total_cpu_pc += cpu_pc
-            values.append(('CPU %d' % cpu.cpu_id, cpu_pc))
+
+        for cpu in sorted(self._analysis.cpus.values(),
+                          key=operator.attrgetter('usage_percent'),
+                          reverse=True):
+            values.append(('CPU %d' % cpu.cpu_id, cpu.usage_percent))
+
         for line in graph.graph('Per-CPU Usage', values, unit=' %'):
             print(line)
-        print('\nTotal CPU Usage: %0.02f%%\n' %
-              (total_cpu_pc / len(self.state.cpus.keys())))
+
+    def _print_total_cpu_usage(self):
+        cpu_count = len(self.state.cpus)
+        usage_percent = 0
+
+        for cpu in sorted(self._analysis.cpus.values(),
+                          key=operator.attrgetter('usage_percent'),
+                          reverse=True):
+            usage_percent += cpu.usage_percent
+
+        # average per CPU
+        usage_percent /= cpu_count
+        print('\nTotal CPU Usage: %0.02f%%\n' % usage_percent)
 
     def _add_arguments(self, ap):
         # specific argument


### PR DESCRIPTION
This pull request, the third in the series, decouples the state tracking of sched events and the analysis used to provide CPU usage stats, in order to integrate it with the new analysis project software architecture. It also fixes a number of bugs, notably pertaining to the inheritance of FDs on fork and to the setting of the CLOEXEC flag on these FDs.