### PR TITLE
Refactor and clean-up cli and core

### DIFF
--- a/lttng-iolog
+++ b/lttng-iolog
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+#
+# The MIT License (MIT)
+#
+# Copyright (C) 2015 - Julien Desfossez <jdesfossez@efficios.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from lttnganalyses.cli import io
+
+
+if __name__ == '__main__':
+    io.runlog()

--- a/lttnganalyses/cli/cputop.py
+++ b/lttnganalyses/cli/cputop.py
@@ -31,51 +31,14 @@ import operator
 
 class Cputop(Command):
     _DESC = """The cputop command."""
-
-    def __init__(self):
-        super().__init__(self._add_arguments, enable_proc_filter_args=True)
-
-    def _validate_transform_args(self):
-        pass
-
-    def run(self):
-        # parse arguments first
-        self._parse_args()
-        # validate, transform and save specific arguments
-        self._validate_transform_args()
-        # open the trace
-        self._open_trace()
-        # create the appropriate analysis/analyses
-        self._create_analysis()
-        # run the analysis
-        self._run_analysis(self._reset_total, self._refresh)
-        # process the results
-        self._compute_stats()
-        # print results
-        self._print_results(self.start_ns, self.trace_end_ts)
-        # close the trace
-        self._close_trace()
-
-    def _create_analysis(self):
-        self._analysis = cputop.Cputop(self.state)
-
-    def _compute_stats(self):
-        self._analysis.compute_stats(self.start_ns, self.end_ns)
-
-    def _reset_total(self, start_ts):
-        self._analysis.reset(start_ts)
-
-    def _refresh(self, begin, end):
-        self._compute_stats()
-        self._print_results(begin, end)
-        self._reset_total(end)
+    _ANALYSIS_CLASS = cputop.Cputop
 
     def _filter_process(self, proc):
         # Exclude swapper
         if proc.tid == 0:
             return False
 
-        if self._arg_proc_list and proc.comm not in self._arg_proc_list:
+        if self._args.proc_list and proc.comm not in self._args.proc_list:
             return False
 
         return True
@@ -88,7 +51,7 @@ class Cputop(Command):
 
     def _print_per_tid_usage(self):
         count = 0
-        limit = self._arg_limit
+        limit = self._args.limit
         graph = Pyasciigraph()
         values = []
 
@@ -140,14 +103,9 @@ class Cputop(Command):
         print('\nTotal CPU Usage: %0.02f%%\n' % usage_percent)
 
     def _add_arguments(self, ap):
-        # specific argument
-        pass
+        Command._add_proc_filter_args(ap)
 
 
-# entry point
 def run():
-    # create command
     cputopcmd = Cputop()
-
-    # execute command
     cputopcmd.run()

--- a/lttnganalyses/cli/cputop.py
+++ b/lttnganalyses/cli/cputop.py
@@ -127,6 +127,9 @@ class Cputop(Command):
         cpu_count = len(self.state.cpus)
         usage_percent = 0
 
+        if not cpu_count:
+            return
+
         for cpu in sorted(self._analysis.cpus.values(),
                           key=operator.attrgetter('usage_percent'),
                           reverse=True):

--- a/lttnganalyses/cli/io.py
+++ b/lttnganalyses/cli/io.py
@@ -280,7 +280,7 @@ class IoAnalysisCommand(Command):
                        common.MSEC_PER_NSEC)
         avg_latency = round(avg_latency, 3)
 
-        return ('%s' % disk.disk_name, avg_latency)
+        return (disk.disk_name, avg_latency)
 
     def _get_net_recv_bytes_datum(self, iface):
         return ('%s %s' % (common.convert_size(iface.recv_bytes), iface.name),

--- a/lttnganalyses/cli/memtop.py
+++ b/lttnganalyses/cli/memtop.py
@@ -31,38 +31,7 @@ import operator
 
 class Memtop(Command):
     _DESC = """The memtop command."""
-
-    def __init__(self):
-        super().__init__(self._add_arguments, enable_proc_filter_args=True)
-
-    def _validate_transform_args(self):
-        pass
-
-    def run(self):
-        # parse arguments first
-        self._parse_args()
-        # validate, transform and save specific arguments
-        self._validate_transform_args()
-        # open the trace
-        self._open_trace()
-        # create the appropriate analysis/analyses
-        self._create_analysis()
-        # run the analysis
-        self._run_analysis(self._reset_total, self._refresh)
-        # print results
-        self._print_results(self.start_ns, self.trace_end_ts)
-        # close the trace
-        self._close_trace()
-
-    def _create_analysis(self):
-        self._analysis = memtop.Memtop(self.state)
-
-    def _reset_total(self, start_ts):
-        self._analysis.reset()
-
-    def _refresh(self, begin, end):
-        self._print_results(begin, end)
-        self._reset_total(end)
+    _ANALYSIS_CLASS = memtop.Memtop
 
     def _print_results(self, begin_ns, end_ns):
         self._print_date(begin_ns, end_ns)
@@ -82,10 +51,10 @@ class Memtop(Command):
                 continue
 
             values.append(('%s (%d)' % (tid.comm, tid.tid),
-                          tid.allocated_pages))
+                           tid.allocated_pages))
 
             count += 1
-            if self._arg_limit > 0 and count >= self._arg_limit:
+            if self._args.limit > 0 and count >= self._args.limit:
                 break
 
         for line in graph.graph('Per-TID Memory Allocations', values,
@@ -106,7 +75,7 @@ class Memtop(Command):
             values.append(('%s (%d)' % (tid.comm, tid.tid), tid.freed_pages))
 
             count += 1
-            if self._arg_limit > 0 and count >= self._arg_limit:
+            if self._args.limit > 0 and count >= self._args.limit:
                 break
 
         for line in graph.graph('Per-TID Memory Deallocation', values,
@@ -128,14 +97,9 @@ class Memtop(Command):
               (alloc, freed))
 
     def _add_arguments(self, ap):
-        # specific argument
-        pass
+        Command._add_proc_filter_args(ap)
 
 
-# entry point
 def run():
-    # create command
     memtopcmd = Memtop()
-
-    # execute command
     memtopcmd.run()

--- a/lttnganalyses/cli/progressbar.py
+++ b/lttnganalyses/cli/progressbar.py
@@ -35,24 +35,24 @@ except ImportError:
 BYTES_PER_EVENT = 30
 
 
-def getFolderSize(folder):
+def get_folder_size(folder):
     total_size = os.path.getsize(folder)
     for item in os.listdir(folder):
         itempath = os.path.join(folder, item)
         if os.path.isfile(itempath):
             total_size += os.path.getsize(itempath)
         elif os.path.isdir(itempath):
-            total_size += getFolderSize(itempath)
+            total_size += get_folder_size(itempath)
     return total_size
 
 
 def progressbar_setup(obj):
-    if hasattr(obj, '_arg_no_progress') and obj._arg_no_progress:
+    if obj._args.no_progress:
         obj.pbar = None
         return
 
     if progressbar_available:
-        size = getFolderSize(obj._arg_path)
+        size = get_folder_size(obj._args.path)
         widgets = ['Processing the trace: ', Percentage(), ' ',
                    Bar(marker='#', left='[', right=']'),
                    ' ', ETA(), ' ']  # see docs for other options
@@ -62,15 +62,15 @@ def progressbar_setup(obj):
     else:
         print('Warning: progressbar module not available, '
               'using --no-progress.', file=sys.stderr)
-        obj._arg_no_progress = True
+        obj._args.no_progress = True
         obj.pbar = None
     obj.event_count = 0
 
 
 def progressbar_update(obj):
-    if hasattr(obj, '_arg_no_progress') and \
-            (obj._arg_no_progress or obj.pbar is None):
+    if obj._args.no_progress or obj.pbar is None:
         return
+
     try:
         obj.pbar.update(obj.event_count)
     except ValueError:
@@ -79,6 +79,6 @@ def progressbar_update(obj):
 
 
 def progressbar_finish(obj):
-    if hasattr(obj, '_arg_no_progress') and obj._arg_no_progress:
+    if obj._args.no_progress:
         return
     obj.pbar.finish()

--- a/lttnganalyses/cli/syscallstats.py
+++ b/lttnganalyses/cli/syscallstats.py
@@ -33,27 +33,7 @@ import errno
 
 class SyscallsAnalysis(Command):
     _DESC = """The syscallstats command."""
-
-    def __init__(self):
-        super().__init__(self._add_arguments, enable_proc_filter_args=True)
-
-    def _validate_transform_args(self):
-        pass
-
-    def run(self):
-        self._parse_args()
-        self._validate_transform_args()
-        self._open_trace()
-        self._create_analysis()
-        self._run_analysis(self._reset_total, self._refresh)
-        self._print_results(self.start_ns, self.trace_end_ts)
-        self._close_trace()
-
-    def _create_analysis(self):
-        self._analysis = syscalls.SyscallsAnalysis(self.state)
-
-    def _refresh(self, begin, end):
-        self._print_results(begin, end)
+    _ANALYSIS_CLASS = syscalls.SyscallsAnalysis
 
     def _print_results(self, begin_ns, end_ns):
         line_format = '{:<38} {:>14} {:>14} {:>14} {:>12} {:>10}  {:<14}'
@@ -119,11 +99,8 @@ class SyscallsAnalysis(Command):
 
         print('\nTotal syscalls: %d' % (self._analysis.total_syscalls))
 
-    def _reset_total(self, start_ts):
-        pass
-
     def _add_arguments(self, ap):
-        pass
+        Command._add_proc_filter_args(ap)
 
 
 def run():

--- a/lttnganalyses/core/io.py
+++ b/lttnganalyses/core/io.py
@@ -27,7 +27,7 @@ from ..linuxautomaton import sv
 
 
 class IoAnalysis(Analysis):
-    def __init__(self, state):
+    def __init__(self, state, conf):
         notification_cbs = {
             'net_dev_xmit': self._process_net_dev_xmit,
             'netif_receive_skb': self._process_netif_receive_skb,
@@ -43,7 +43,7 @@ class IoAnalysis(Analysis):
             self._process_lttng_statedump_block_device
         }
 
-        self._state = state
+        super().__init__(state, conf)
         self._state.register_notification_cbs(notification_cbs)
         self._register_cbs(event_cbs)
 
@@ -52,6 +52,7 @@ class IoAnalysis(Analysis):
         self.tids = {}
 
     def process_event(self, ev):
+        super().process_event(ev)
         self._process_event_cb(ev)
 
     def reset(self):

--- a/lttnganalyses/core/irq.py
+++ b/lttnganalyses/core/irq.py
@@ -26,31 +26,21 @@ from .analysis import Analysis
 
 
 class IrqAnalysis(Analysis):
-    def __init__(self, state, min_duration, max_duration):
+    def __init__(self, state, conf):
         notification_cbs = {
             'irq_handler_entry': self._process_irq_handler_entry,
             'irq_handler_exit': self._process_irq_handler_exit,
             'softirq_exit': self._process_softirq_exit
         }
 
-        self._state = state
+        super().__init__(state, conf)
         self._state.register_notification_cbs(notification_cbs)
-        self._min_duration = min_duration
-        self._max_duration = max_duration
-        # µs to ns
-        if self._min_duration is not None:
-            self._min_duration *= 1000
-        if self._max_duration is not None:
-            self._max_duration *= 1000
 
         # Indexed by irq 'id' (irq or vec)
         self.hard_irq_stats = {}
         self.softirq_stats = {}
         # Log of individual interrupts
         self.irq_list = []
-
-    def process_event(self, ev):
-        pass
 
     def reset(self):
         self.irq_list = []
@@ -71,9 +61,11 @@ class IrqAnalysis(Analysis):
         irq = kwargs['hard_irq']
 
         duration = irq.end_ts - irq.begin_ts
-        if self._min_duration is not None and duration < self._min_duration:
+        if self._conf.min_duration is not None and \
+           duration < self._conf.min_duration:
             return
-        if self._max_duration is not None and duration > self._max_duration:
+        if self._conf.max_duration is not None and \
+           duration > self._conf.max_duration:
             return
 
         self.irq_list.append(irq)
@@ -86,9 +78,11 @@ class IrqAnalysis(Analysis):
         irq = kwargs['softirq']
 
         duration = irq.end_ts - irq.begin_ts
-        if self._min_duration is not None and duration < self._min_duration:
+        if self._conf.min_duration is not None and \
+           duration < self._conf.min_duration:
             return
-        if self._max_duration is not None and duration > self._max_duration:
+        if self._conf.max_duration is not None and \
+           duration > self._conf.max_duration:
             return
 
         self.irq_list.append(irq)

--- a/lttnganalyses/core/memtop.py
+++ b/lttnganalyses/core/memtop.py
@@ -26,18 +26,16 @@ from .analysis import Analysis
 
 
 class Memtop(Analysis):
-    def __init__(self, state):
+    def __init__(self, state, conf):
         notification_cbs = {
             'tid_page_alloc': self._process_tid_page_alloc,
             'tid_page_free': self._process_tid_page_free
         }
 
-        self._state = state
+        super().__init__(state, conf)
         self._state.register_notification_cbs(notification_cbs)
-        self.tids = {}
 
-    def process_event(self, ev):
-        pass
+        self.tids = {}
 
     def reset(self):
         for tid in self.tids:

--- a/lttnganalyses/core/syscalls.py
+++ b/lttnganalyses/core/syscalls.py
@@ -26,18 +26,16 @@ from .analysis import Analysis
 
 
 class SyscallsAnalysis(Analysis):
-    def __init__(self, state):
+    def __init__(self, state, conf):
         notification_cbs = {
             'syscall_exit': self._process_syscall_exit
         }
 
-        self._state = state
+        super().__init__(state, conf)
         self._state.register_notification_cbs(notification_cbs)
+
         self.tids = {}
         self.total_syscalls = 0
-
-    def process_event(self, ev):
-        pass
 
     def reset(self):
         pass


### PR DESCRIPTION
This refactor mainly refactors modules within the cli package in order
to reduce the duplicated code between separate commands. This allows
for new analyses to be added in a much simpler fashion.

The second significant portion of the refactor is the removal of all
refresh/reset or otherwise analysis-state affecting code from the cli,
and its reimplementation within the analysis itself. The cli now
simply feeds events to the analysis (and state automaton), and
receives notifications to which it can react. For now, the only
notification type is received whenever an analysis period has ended,
in which case the default cli behaviour is to output the results.

Some other minor style clean-up is also performed where was deemed
necessary.

Also included in the PR are other commits fixing minor bugs or omissions.