### PR TITLE
Periodic analysis implementation

### DIFF
--- a/lttnganalyses/cli/command.py
+++ b/lttnganalyses/cli/command.py
@@ -108,6 +108,8 @@ class Command:
     def _validate_transform_common_args(self, args):
         self._analysis_conf = analysis.AnalysisConfig()
         self._analysis_conf.refresh_period = args.refresh
+        self._analysis_conf.period_begin_ev_name = args.period_begin
+        self._analysis_conf.period_end_ev_name = args.period_end
 
         # convert min/max args from µs to ns, if needed
         if hasattr(args, 'min') and args.min is not None:
@@ -153,6 +155,11 @@ class Command:
                                                 'hh:mm:ss[.nnnnnnnnn]')
         ap.add_argument('--timerange', type=str, help='time range: '
                                                       '[begin,end]')
+        ap.add_argument('--period-begin', type=str,
+                        help='Analysis period start marker event name')
+        ap.add_argument('--period-end', type=str,
+                        help='Analysis period end marker event name '
+                        '(requires --period-begin)')
         ap.add_argument('-V', '--version', action='version',
                         version='LTTng Analyses v' + __version__)
 

--- a/lttnganalyses/cli/command.py
+++ b/lttnganalyses/cli/command.py
@@ -117,6 +117,7 @@ class Command:
         self._analysis_conf.refresh_period = refresh_period_ns
         self._analysis_conf.period_begin_ev_name = args.period_begin
         self._analysis_conf.period_end_ev_name = args.period_end
+        self._analysis_conf.period_key_fields = args.period_key.split(',')
 
         # convert min/max args from µs to ns, if needed
         if hasattr(args, 'min') and args.min is not None:
@@ -168,6 +169,9 @@ class Command:
         ap.add_argument('--period-end', type=str,
                         help='Analysis period end marker event name '
                         '(requires --period-begin)')
+        ap.add_argument('--period-key', type=str, default='cpu_id',
+                        help='Optional, list of event field names used to match '
+                        'period markers (default: cpu_id)')
         ap.add_argument('-V', '--version', action='version',
                         version='LTTng Analyses v' + __version__)
 

--- a/lttnganalyses/cli/command.py
+++ b/lttnganalyses/cli/command.py
@@ -106,8 +106,15 @@ class Command:
         print(date)
 
     def _validate_transform_common_args(self, args):
+        refresh_period_ns = None
+        if args.refresh is not None:
+            try:
+                refresh_period_ns = common.duration_str_to_ns(args.refresh)
+            except ValueError as e:
+                self._cmdline_error(str(e))
+
         self._analysis_conf = analysis.AnalysisConfig()
-        self._analysis_conf.refresh_period = args.refresh
+        self._analysis_conf.refresh_period = refresh_period_ns
         self._analysis_conf.period_begin_ev_name = args.period_begin
         self._analysis_conf.period_end_ev_name = args.period_end
 
@@ -138,8 +145,9 @@ class Command:
 
         # common arguments
         ap.add_argument('path', metavar='<path/to/trace>', help='trace path')
-        ap.add_argument('-r', '--refresh', type=int,
-                        help='Refresh period in seconds')
+        ap.add_argument('-r', '--refresh', type=str,
+                        help='Refresh period, with optional units suffix '
+                        '(default units: s)')
         ap.add_argument('--limit', type=int, default=10,
                         help='Limit to top X (default = 10)')
         ap.add_argument('--no-progress', action='store_true',

--- a/lttnganalyses/cli/io.py
+++ b/lttnganalyses/cli/io.py
@@ -215,7 +215,7 @@ class IoAnalysisCommand(Command):
             return None
 
         avg_latency = ((disk.total_rq_duration / disk.rq_count) /
-                       common.MSEC_PER_NSEC)
+                       common.NSEC_PER_MSEC)
         avg_latency = round(avg_latency, 3)
 
         return (disk.disk_name, avg_latency)

--- a/lttnganalyses/core/analysis.py
+++ b/lttnganalyses/core/analysis.py
@@ -46,9 +46,6 @@ class Analysis:
         self._notification_cbs = {}
         self._cbs = {}
 
-        if self._conf.refresh_period is not None:
-            self._conf.refresh_period *= common.NSEC_PER_SEC
-
         self.started = False
         self.ended = False
 

--- a/lttnganalyses/core/cputop.py
+++ b/lttnganalyses/core/cputop.py
@@ -146,7 +146,10 @@ class CpuUsageStats():
         self.usage_percent = None
 
     def compute_stats(self, duration):
-        self.usage_percent = self.total_usage_time * 100 / duration
+        if duration != 0:
+            self.usage_percent = self.total_usage_time * 100 / duration
+        else:
+            self.usage_percent = 0
 
     def reset(self, timestamp):
         self.total_usage_time = 0
@@ -170,7 +173,10 @@ class ProcessCpuStats():
         return cls(proc.tid, proc.comm)
 
     def compute_stats(self, duration):
-        self.usage_percent = self.total_cpu_time * 100 / duration
+        if duration != 0:
+            self.usage_percent = self.total_cpu_time * 100 / duration
+        else:
+            self.usage_percent = 0
 
     def reset(self, timestamp):
         self.total_cpu_time = 0


### PR DESCRIPTION
This pull request includes changes to allow periodic analysis, either defined by a set period length or delimited by one or two event markers, paired using a default or user specified key made up of values extracted from the event's fields.

The `--refresh` cli argument has been changed to support units other than seconds, as well as floating point values. The default behaviour of assuming seconds as the units is still retained, however, when no suffix is added to the numeric value.

The user can also define a `--period-begin` event name. When specified alone, this marks both the beginning of a new period and the end of the preceding one (if any). If `--period-end` is also specified, only this second event terminates an analysis period. Pairs of markers are matched by comparing values for one or more of their fields, forming a key. The current default is to compare `cpu_id` values, but the user can specify a comma-separated list of fields via `--period-key` to override this.

Overlapping periods are not currently supported, thus only the period whose begin event has occurred the earliest will be considered in a situation where periods might overlap.

Note that using `--period-begin` (alone or combined with the other `--period-*` fields) overrides the analysis period provided by `--refresh`.