### PR TITLE
Add a LICENSE file and a stand-alone copy of the MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,5 @@
+LTTng-Analyses - Licensing
+
+These analyses are released under the MIT license. This license is used to
+allow the use of these analyses in both free and proprietary software. See
+mit-license.txt for details.

--- a/mit-license.txt
+++ b/mit-license.txt
@@ -1,0 +1,19 @@
+Copyright (c) ...
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
A LICENSE file is provided for all other LTTng projects. These
files are added to maintain uniformity among the projects'
organization.

Signed-off-by: Jérémie Galarneau <jeremie.galarneau@efficios.com>