### PR TITLE
Fix: Include tests dir in source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include versioneer.py
+recursive-include tests *


### PR DESCRIPTION
The test suite is referenced in the setup.py but is not included in the source distribution.