### PR TITLE
Fix: keep the trace and output if a test fails

### DIFF
--- a/tests/test_cputop.py
+++ b/tests/test_cputop.py
@@ -44,4 +44,4 @@ class CpuTest(AnalysisTest):
         expected = self.get_expected_output('cputop.txt')
         result = self.get_cmd_output('lttng-cputop')
 
-        self.assertMultiLineEqual(result, expected)
+        self.diff("cputop", result, expected)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -68,10 +68,10 @@ class IoTest(AnalysisTest):
         expected = self.get_expected_output('iousagetop.txt')
         result = self.get_cmd_output('lttng-iousagetop')
 
-        self.assertMultiLineEqual(result, expected)
+        self.diff("iousagetop", result, expected)
 
     def test_iolatencytop(self):
         expected = self.get_expected_output('iolatencytop.txt')
         result = self.get_cmd_output('lttng-iolatencytop')
 
-        self.assertMultiLineEqual(result, expected)
+        self.diff("iolatencytop", result, expected)

--- a/tests/test_irq.py
+++ b/tests/test_irq.py
@@ -78,10 +78,10 @@ class IrqTest(AnalysisTest):
         expected = self.get_expected_output('irqstats.txt')
         result = self.get_cmd_output('lttng-irqstats')
 
-        self.assertMultiLineEqual(result, expected)
+        self.diff("irqstats", result, expected)
 
     def test_irqlog(self):
         expected = self.get_expected_output('irqlog.txt')
         result = self.get_cmd_output('lttng-irqlog')
 
-        self.assertMultiLineEqual(result, expected)
+        self.diff("irqlog", result, expected)


### PR DESCRIPTION
Instead of always removing the traces and only outputting a diff, if the
test fails, we now keep the trace and the output we got, so it is easy
to reproduce afterwards or just copy the new output to the "expected"
folder if it is correct.

Signed-off-by: Julien Desfossez <jdesfossez@efficios.com>