### PR TITLE
Fix: keep the trace and output if a test fails 

### DIFF
--- a/tests/analysis_test.py
+++ b/tests/analysis_test.py
@@ -55,8 +55,9 @@ class AnalysisTest(unittest.TestCase):
 
         return result
 
-    def get_expected_output(self, filename):
-        with open(self.data_path + filename, 'r') as expected_file:
+    def get_expected_output(self, test_name):
+        expected_path = os.path.join(self.data_path, test_name + '.txt')
+        with open(expected_path, 'r') as expected_file:
             return expected_file.read()
 
     def get_cmd_output(self, exec_name, options=''):
@@ -66,15 +67,15 @@ class AnalysisTest(unittest.TestCase):
 
         return subprocess.getoutput(cmd)
 
-    def get_output(self, name, output):
-        out = open(os.path.join(self.trace_writer.trace_root, name), "w")
-        out.write(output)
-        out.close()
-        self.rm_trace = False
+    def save_test_result(self, result, test_name):
+        result_path = os.path.join(self.trace_writer.trace_root, test_name)
+        with open(result_path, 'w') as result_file:
+            result_file.write(result)
+            self.rm_trace = False
 
-    def diff(self, name, result, expected):
+    def _assertMultiLineEqual(self, result, expected, test_name):
         try:
             self.assertMultiLineEqual(result, expected)
         except AssertionError:
-            self.get_output(name, result)
+            self.save_test_result(result, test_name)
             raise

--- a/tests/test_cputop.py
+++ b/tests/test_cputop.py
@@ -44,4 +44,4 @@ class CpuTest(AnalysisTest):
         expected = self.get_expected_output('cputop.txt')
         result = self.get_cmd_output('lttng-cputop')
 
-        self.assertMultiLineEqual(result, expected)
+        self.diff("cputop", result, expected)

--- a/tests/test_cputop.py
+++ b/tests/test_cputop.py
@@ -41,7 +41,8 @@ class CpuTest(AnalysisTest):
         self.trace_writer.flush()
 
     def test_cputop(self):
-        expected = self.get_expected_output('cputop.txt')
+        test_name = 'cputop'
+        expected = self.get_expected_output(test_name)
         result = self.get_cmd_output('lttng-cputop')
 
-        self.diff("cputop", result, expected)
+        self._assertMultiLineEqual(result, expected, test_name)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -68,10 +68,10 @@ class IoTest(AnalysisTest):
         expected = self.get_expected_output('iousagetop.txt')
         result = self.get_cmd_output('lttng-iousagetop')
 
-        self.assertMultiLineEqual(result, expected)
+        self.diff("iousagetop", result, expected)
 
     def test_iolatencytop(self):
         expected = self.get_expected_output('iolatencytop.txt')
         result = self.get_cmd_output('lttng-iolatencytop')
 
-        self.assertMultiLineEqual(result, expected)
+        self.diff("iolatencytop", result, expected)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -65,13 +65,15 @@ class IoTest(AnalysisTest):
         self.trace_writer.flush()
 
     def test_iousagetop(self):
-        expected = self.get_expected_output('iousagetop.txt')
+        test_name = 'iousagetop'
+        expected = self.get_expected_output(test_name)
         result = self.get_cmd_output('lttng-iousagetop')
 
-        self.diff("iousagetop", result, expected)
+        self._assertMultiLineEqual(result, expected, test_name)
 
     def test_iolatencytop(self):
-        expected = self.get_expected_output('iolatencytop.txt')
+        test_name = 'iolatencytop'
+        expected = self.get_expected_output(test_name)
         result = self.get_cmd_output('lttng-iolatencytop')
 
-        self.diff("iolatencytop", result, expected)
+        self._assertMultiLineEqual(result, expected, test_name)

--- a/tests/test_irq.py
+++ b/tests/test_irq.py
@@ -75,13 +75,15 @@ class IrqTest(AnalysisTest):
         self.trace_writer.flush()
 
     def test_irqstats(self):
-        expected = self.get_expected_output('irqstats.txt')
+        test_name = 'irqstats'
+        expected = self.get_expected_output(test_name)
         result = self.get_cmd_output('lttng-irqstats')
 
-        self.diff("irqstats", result, expected)
+        self._assertMultiLineEqual(result, expected, test_name)
 
     def test_irqlog(self):
-        expected = self.get_expected_output('irqlog.txt')
+        test_name = 'irqlog'
+        expected = self.get_expected_output(test_name)
         result = self.get_cmd_output('lttng-irqlog')
 
-        self.diff("irqlog", result, expected)
+        self._assertMultiLineEqual(result, expected, test_name)

--- a/tests/test_irq.py
+++ b/tests/test_irq.py
@@ -78,10 +78,10 @@ class IrqTest(AnalysisTest):
         expected = self.get_expected_output('irqstats.txt')
         result = self.get_cmd_output('lttng-irqstats')
 
-        self.assertMultiLineEqual(result, expected)
+        self.diff("irqstats", result, expected)
 
     def test_irqlog(self):
         expected = self.get_expected_output('irqlog.txt')
         result = self.get_cmd_output('lttng-irqlog')
 
-        self.assertMultiLineEqual(result, expected)
+        self.diff("irqlog", result, expected)


### PR DESCRIPTION
This is the updated version of #38, with style issues addressed and some clean-up.