### PR TITLE
Fix: check tid and cpu filters on upate_fd callback

### DIFF
--- a/lttnganalyses/core/io.py
+++ b/lttnganalyses/core/io.py
@@ -308,7 +308,13 @@ class IoAnalysis(Analysis):
     def _process_update_fd(self, **kwargs):
         parent_proc = kwargs['parent_proc']
         tid = parent_proc.tid
+        cpu = kwargs['cpu_id']
         fd = kwargs['fd']
+
+        if not self._filter_process(parent_proc):
+            return
+        if not self._filter_cpu(cpu):
+            return
 
         new_filename = parent_proc.fds[fd].filename
         fd_list = self.tids[tid].fds[fd]


### PR DESCRIPTION
We must not perform the filename update if the callback is for a
process or on a CPU that was filtered out by the user.

Fixes #65

Signed-off-by: Antoine Busque <antoinebusque@gmail.com>
