### PR TITLE
Fix: use en_US.UTF-8 locale for tests

### DIFF
--- a/tests/integration/analysis_test.py
+++ b/tests/integration/analysis_test.py
@@ -67,7 +67,7 @@ class AnalysisTest(unittest.TestCase):
 
         # Create an utf-8 test env
         test_env = os.environ.copy()
-        test_env['LC_ALL'] = 'C.UTF-8'
+        test_env['LC_ALL'] = 'en_US.UTF-8'
 
         process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
                                    stderr=subprocess.STDOUT, env=test_env)


### PR DESCRIPTION
The C.UTF-8 locale is not available on all distributions, therefore we
use the near-equivalent en_US.UTF-8 instead.

Signed-off-by: Antoine Busque <abusque@efficios.com>