### PR TITLE
Nested periods

### DIFF
--- a/lttnganalyses/cli/command.py
+++ b/lttnganalyses/cli/command.py
@@ -367,11 +367,17 @@ class Command:
         if self._args.min is not None:
             self._args.uniform_min = self._args.min
         else:
-            self._args.uniform_min = min(durations)
+            if len(durations) == 0:
+                self._args.uniform_min = 0
+            else:
+                self._args.uniform_min = min(durations)
         if self._args.max is not None:
             self._args.uniform_max = self._args.max
         else:
-            self._args.uniform_max = max(durations)
+            if len(durations) == 0:
+                self._args.uniform_max = 0
+            else:
+                self._args.uniform_max = max(durations)
 
         # ns to µs
         self._args.uniform_min /= 1000

--- a/lttnganalyses/cli/command.py
+++ b/lttnganalyses/cli/command.py
@@ -830,12 +830,9 @@ Please consider using the --period option.''')
         self._automaton = automaton.Automaton()
         self.state = self._automaton.state
 
-    def _analysis_tick_cb(self, period, **kwargs):
-        begin_ns = kwargs['begin_ns']
-        end_ns = kwargs['end_ns']
-
-        self._analysis_tick(period, begin_ns, end_ns)
+    def _analysis_tick_cb(self, period, end_ns):
+        self._analysis_tick(period, end_ns)
         self._ticks += 1
 
-    def _analysis_tick(self, period, begin_ns, end_ns):
+    def _analysis_tick(self, period, end_ns):
         raise NotImplementedError()

--- a/lttnganalyses/cli/cputop.py
+++ b/lttnganalyses/cli/cputop.py
@@ -71,10 +71,15 @@ class Cputop(Command):
         ),
     ]
 
-    def _analysis_tick(self, begin_ns, end_ns):
-        per_tid_table = self._get_per_tid_usage_result_table(begin_ns, end_ns)
-        per_cpu_table = self._get_per_cpu_usage_result_table(begin_ns, end_ns)
-        total_table = self._get_total_usage_result_table(begin_ns, end_ns)
+    def _analysis_tick(self, period, begin_ns, end_ns):
+        if period is None:
+            return
+        per_tid_table = self._get_per_tid_usage_result_table(period, begin_ns,
+                                                             end_ns)
+        per_cpu_table = self._get_per_cpu_usage_result_table(period, begin_ns,
+                                                             end_ns)
+        total_table = self._get_total_usage_result_table(period, begin_ns,
+                                                         end_ns)
 
         if self._mi_mode:
             self._mi_append_result_table(per_tid_table)
@@ -106,13 +111,13 @@ class Cputop(Command):
         self._mi_clear_result_tables()
         self._mi_append_result_table(summary_table)
 
-    def _get_per_tid_usage_result_table(self, begin_ns, end_ns):
+    def _get_per_tid_usage_result_table(self, period, begin_ns, end_ns):
         result_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_PER_PROC,
                                          begin_ns, end_ns)
         count = 0
 
-        for tid in sorted(self._analysis.tids.values(),
+        for tid in sorted(period.tids.values(),
                           key=operator.attrgetter('usage_percent'),
                           reverse=True):
             prio_list = format_utils.format_prio_list(tid.prio_list)
@@ -130,12 +135,12 @@ class Cputop(Command):
 
         return result_table
 
-    def _get_per_cpu_usage_result_table(self, begin_ns, end_ns):
+    def _get_per_cpu_usage_result_table(self, period, begin_ns, end_ns):
         result_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_PER_CPU,
                                          begin_ns, end_ns)
 
-        for cpu in sorted(self._analysis.cpus.values(),
+        for cpu in sorted(period.cpus.values(),
                           key=operator.attrgetter('cpu_id')):
             result_table.append_row(
                 cpu=mi.Cpu(cpu.cpu_id),
@@ -144,7 +149,7 @@ class Cputop(Command):
 
         return result_table
 
-    def _get_total_usage_result_table(self, begin_ns, end_ns):
+    def _get_total_usage_result_table(self, period, begin_ns, end_ns):
         result_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_TOTAL,
                                          begin_ns, end_ns)
@@ -155,7 +160,7 @@ class Cputop(Command):
         if not cpu_count:
             return
 
-        for cpu in sorted(self._analysis.cpus.values(),
+        for cpu in sorted(period.cpus.values(),
                           key=operator.attrgetter('usage_percent'),
                           reverse=True):
             usage_percent += cpu.usage_percent

--- a/lttnganalyses/cli/cputop.py
+++ b/lttnganalyses/cli/cputop.py
@@ -71,14 +71,16 @@ class Cputop(Command):
         ),
     ]
 
-    def _analysis_tick(self, period, begin_ns, end_ns):
-        if period is None:
+    def _analysis_tick(self, period_data, end_ns):
+        if period_data is None:
             return
-        per_tid_table = self._get_per_tid_usage_result_table(period, begin_ns,
-                                                             end_ns)
-        per_cpu_table = self._get_per_cpu_usage_result_table(period, begin_ns,
-                                                             end_ns)
-        total_table = self._get_total_usage_result_table(period, begin_ns,
+
+        begin_ns = period_data.period.begin_evt.timestamp
+        per_tid_table = self._get_per_tid_usage_result_table(period_data,
+                                                             begin_ns, end_ns)
+        per_cpu_table = self._get_per_cpu_usage_result_table(period_data,
+                                                             begin_ns, end_ns)
+        total_table = self._get_total_usage_result_table(period_data, begin_ns,
                                                          end_ns)
 
         if self._mi_mode:
@@ -111,13 +113,13 @@ class Cputop(Command):
         self._mi_clear_result_tables()
         self._mi_append_result_table(summary_table)
 
-    def _get_per_tid_usage_result_table(self, period, begin_ns, end_ns):
+    def _get_per_tid_usage_result_table(self, period_data, begin_ns, end_ns):
         result_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_PER_PROC,
                                          begin_ns, end_ns)
         count = 0
 
-        for tid in sorted(period.tids.values(),
+        for tid in sorted(period_data.tids.values(),
                           key=operator.attrgetter('usage_percent'),
                           reverse=True):
             prio_list = format_utils.format_prio_list(tid.prio_list)
@@ -135,12 +137,12 @@ class Cputop(Command):
 
         return result_table
 
-    def _get_per_cpu_usage_result_table(self, period, begin_ns, end_ns):
+    def _get_per_cpu_usage_result_table(self, period_data, begin_ns, end_ns):
         result_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_PER_CPU,
                                          begin_ns, end_ns)
 
-        for cpu in sorted(period.cpus.values(),
+        for cpu in sorted(period_data.cpus.values(),
                           key=operator.attrgetter('cpu_id')):
             result_table.append_row(
                 cpu=mi.Cpu(cpu.cpu_id),
@@ -149,7 +151,7 @@ class Cputop(Command):
 
         return result_table
 
-    def _get_total_usage_result_table(self, period, begin_ns, end_ns):
+    def _get_total_usage_result_table(self, period_data, begin_ns, end_ns):
         result_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_TOTAL,
                                          begin_ns, end_ns)
@@ -160,7 +162,7 @@ class Cputop(Command):
         if not cpu_count:
             return
 
-        for cpu in sorted(period.cpus.values(),
+        for cpu in sorted(period_data.cpus.values(),
                           key=operator.attrgetter('usage_percent'),
                           reverse=True):
             usage_percent += cpu.usage_percent

--- a/lttnganalyses/cli/io.py
+++ b/lttnganalyses/cli/io.py
@@ -191,9 +191,11 @@ class IoAnalysisCommand(Command):
     _LATENCY_STATS_FORMAT = '{:<14} {:>14} {:>14} {:>14} {:>14} {:>14}'
     _SECTION_SEPARATOR_STRING = '-' * 89
 
-    def _analysis_tick(self, period, begin_ns, end_ns):
-        if period is None:
+    def _analysis_tick(self, period_data, end_ns):
+        if period_data is None:
             return
+
+        begin_ns = period_data.period.begin_evt.timestamp
         syscall_latency_stats_table = None
         disk_latency_stats_table = None
         freq_tables = None
@@ -203,21 +205,24 @@ class IoAnalysisCommand(Command):
 
         if self._args.stats:
             syscall_latency_stats_table, disk_latency_stats_table = \
-                self._get_latency_stats_result_tables(period, begin_ns, end_ns)
+                self._get_latency_stats_result_tables(period_data,
+                                                      begin_ns, end_ns)
 
         if self._args.freq:
-            freq_tables = self._get_freq_result_tables(period, begin_ns,
+            freq_tables = self._get_freq_result_tables(period_data, begin_ns,
                                                        end_ns)
 
         if self._args.usage:
-            usage_tables = self._get_usage_result_tables(period, begin_ns,
+            usage_tables = self._get_usage_result_tables(period_data, begin_ns,
                                                          end_ns)
 
         if self._args.top:
-            top_tables = self._get_top_result_tables(period, begin_ns, end_ns)
+            top_tables = self._get_top_result_tables(period_data,
+                                                     begin_ns, end_ns)
 
         if self._args.log:
-            log_table = self._get_log_result_table(period, begin_ns, end_ns)
+            log_table = self._get_log_result_table(period_data,
+                                                   begin_ns, end_ns)
 
         if self._mi_mode:
             self._mi_append_result_tables([
@@ -290,7 +295,7 @@ class IoAnalysisCommand(Command):
             io_rq.end_ts > self._analysis_conf.end_ts
         )
 
-    def _append_per_proc_read_usage_row(self, period, proc_stats,
+    def _append_per_proc_read_usage_row(self, period_data, proc_stats,
                                         result_table):
         result_table.append_row(
             process=mi.Process(proc_stats.comm, pid=proc_stats.pid,
@@ -303,7 +308,7 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_per_proc_write_usage_row(self, period, proc_stats,
+    def _append_per_proc_write_usage_row(self, period_data, proc_stats,
                                          result_table):
         result_table.append_row(
             process=mi.Process(proc_stats.comm, pid=proc_stats.pid,
@@ -316,7 +321,7 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_per_proc_block_read_usage_row(self, period, proc_stats,
+    def _append_per_proc_block_read_usage_row(self, period_data, proc_stats,
                                               result_table):
         if proc_stats.block_io.read == 0:
             return False
@@ -334,7 +339,7 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_per_proc_block_write_usage_row(self, period, proc_stats,
+    def _append_per_proc_block_write_usage_row(self, period_data, proc_stats,
                                                result_table):
         if proc_stats.block_io.write == 0:
             return False
@@ -352,7 +357,8 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_disk_sector_usage_row(self, period, disk_stats, result_table):
+    def _append_disk_sector_usage_row(self, period_data, disk_stats,
+                                      result_table):
         if disk_stats.total_rq_sectors == 0:
             return None
 
@@ -363,7 +369,8 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_disk_request_usage_row(self, period, disk_stats, result_table):
+    def _append_disk_request_usage_row(self, period_data, disk_stats,
+                                       result_table):
         if disk_stats.rq_count == 0:
             return False
 
@@ -374,7 +381,8 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_disk_rtps_usage_row(self, period, disk_stats, result_table):
+    def _append_disk_rtps_usage_row(self, period_data, disk_stats,
+                                    result_table):
         if disk_stats.rq_count == 0:
             return False
 
@@ -386,7 +394,8 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_netif_recv_usage_row(self, period, netif_stats, result_table):
+    def _append_netif_recv_usage_row(self, period_data, netif_stats,
+                                     result_table):
         result_table.append_row(
             netif=mi.NetIf(netif_stats.name),
             size=mi.Size(netif_stats.recv_bytes)
@@ -394,7 +403,8 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_netif_send_usage_row(self, period, netif_stats, result_table):
+    def _append_netif_send_usage_row(self, period_data, netif_stats,
+                                     result_table):
         result_table.append_row(
             netif=mi.NetIf(netif_stats.name),
             size=mi.Size(netif_stats.sent_bytes)
@@ -402,20 +412,21 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _get_file_stats_fd_owners_str(self, period, file_stats):
+    def _get_file_stats_fd_owners_str(self, period_data, file_stats):
         fd_by_pid_str = ''
 
         for pid, fd in file_stats.fd_by_pid.items():
-            comm = period.tids[pid].comm
+            comm = period_data.tids[pid].comm
             fd_by_pid_str += 'fd %d in %s (%s) ' % (fd, comm, pid)
 
         return fd_by_pid_str
 
-    def _append_file_read_usage_row(self, period, file_stats, result_table):
+    def _append_file_read_usage_row(self, period_data, file_stats,
+                                    result_table):
         if file_stats.io.read == 0:
             return False
 
-        fd_owners = self._get_file_stats_fd_owners_str(period, file_stats)
+        fd_owners = self._get_file_stats_fd_owners_str(period_data, file_stats)
         result_table.append_row(
             path=mi.Path(file_stats.filename),
             size=mi.Size(file_stats.io.read),
@@ -424,11 +435,12 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_file_write_usage_row(self, period, file_stats, result_table):
+    def _append_file_write_usage_row(self, period_data, file_stats,
+                                     result_table):
         if file_stats.io.write == 0:
             return False
 
-        fd_owners = self._get_file_stats_fd_owners_str(period, file_stats)
+        fd_owners = self._get_file_stats_fd_owners_str(period_data, file_stats)
         result_table.append_row(
             path=mi.Path(file_stats.filename),
             size=mi.Size(file_stats.io.write),
@@ -437,112 +449,119 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _fill_usage_result_table(self, period, input_list, append_row_cb,
+    def _fill_usage_result_table(self, period_data, input_list, append_row_cb,
                                  result_table):
         count = 0
         limit = self._args.limit
 
         for elem in input_list:
-            if append_row_cb(period, elem, result_table):
+            if append_row_cb(period_data, elem, result_table):
                 count += 1
 
                 if limit is not None and count >= limit:
                     break
 
-    def _fill_per_process_read_usage_result_table(self, period, result_table):
-        input_list = sorted(period.tids.values(),
+    def _fill_per_process_read_usage_result_table(self, period_data,
+                                                  result_table):
+        input_list = sorted(period_data.tids.values(),
                             key=operator.attrgetter('total_read'),
                             reverse=True)
-        self._fill_usage_result_table(period, input_list,
+        self._fill_usage_result_table(period_data, input_list,
                                       self._append_per_proc_read_usage_row,
                                       result_table)
 
-    def _fill_per_process_write_usage_result_table(self, period, result_table):
-        input_list = sorted(period.tids.values(),
+    def _fill_per_process_write_usage_result_table(self, period_data,
+                                                   result_table):
+        input_list = sorted(period_data.tids.values(),
                             key=operator.attrgetter('total_write'),
                             reverse=True)
-        self._fill_usage_result_table(period, input_list,
+        self._fill_usage_result_table(period_data, input_list,
                                       self._append_per_proc_write_usage_row,
                                       result_table)
 
-    def _fill_per_process_block_read_usage_result_table(self, period,
+    def _fill_per_process_block_read_usage_result_table(self, period_data,
                                                         result_table):
-        input_list = sorted(period.tids.values(),
+        input_list = sorted(period_data.tids.values(),
                             key=operator.attrgetter('block_io.read'),
                             reverse=True)
         self._fill_usage_result_table(
-            period, input_list, self._append_per_proc_block_read_usage_row,
+            period_data, input_list, self._append_per_proc_block_read_usage_row,
             result_table)
 
-    def _fill_per_process_block_write_usage_result_table(self, period,
+    def _fill_per_process_block_write_usage_result_table(self, period_data,
                                                          result_table):
-        input_list = sorted(period.tids.values(),
+        input_list = sorted(period_data.tids.values(),
                             key=operator.attrgetter('block_io.write'),
                             reverse=True)
         self._fill_usage_result_table(
-            period, input_list, self._append_per_proc_block_write_usage_row,
-            result_table)
+            period_data, input_list,
+            self._append_per_proc_block_write_usage_row, result_table)
 
-    def _fill_disk_sector_usage_result_table(self, period, result_table):
-        input_list = sorted(period.disks.values(),
+    def _fill_disk_sector_usage_result_table(self, period_data, result_table):
+        input_list = sorted(period_data.disks.values(),
                             key=operator.attrgetter('total_rq_sectors'),
                             reverse=True)
-        self._fill_usage_result_table(period, input_list,
+        self._fill_usage_result_table(period_data, input_list,
                                       self._append_disk_sector_usage_row,
                                       result_table)
 
-    def _fill_disk_request_usage_result_table(self, period, result_table):
-        input_list = sorted(period.disks.values(),
+    def _fill_disk_request_usage_result_table(self, period_data, result_table):
+        input_list = sorted(period_data.disks.values(),
                             key=operator.attrgetter('rq_count'),
                             reverse=True)
-        self._fill_usage_result_table(period, input_list,
+        self._fill_usage_result_table(period_data, input_list,
                                       self._append_disk_request_usage_row,
                                       result_table)
 
-    def _fill_disk_rtps_usage_result_table(self, period, result_table):
-        input_list = period.disks.values()
-        self._fill_usage_result_table(period, input_list,
+    def _fill_disk_rtps_usage_result_table(self, period_data, result_table):
+        input_list = period_data.disks.values()
+        self._fill_usage_result_table(period_data, input_list,
                                       self._append_disk_rtps_usage_row,
                                       result_table)
 
-    def _fill_netif_recv_usage_result_table(self, period, result_table):
-        input_list = sorted(period.ifaces.values(),
+    def _fill_netif_recv_usage_result_table(self, period_data, result_table):
+        input_list = sorted(period_data.ifaces.values(),
                             key=operator.attrgetter('recv_bytes'),
                             reverse=True)
-        self._fill_usage_result_table(period, input_list,
+        self._fill_usage_result_table(period_data, input_list,
                                       self._append_netif_recv_usage_row,
                                       result_table)
 
-    def _fill_netif_send_usage_result_table(self, period, result_table):
-        input_list = sorted(period.ifaces.values(),
+    def _fill_netif_send_usage_result_table(self, period_data, result_table):
+        input_list = sorted(period_data.ifaces.values(),
                             key=operator.attrgetter('sent_bytes'),
                             reverse=True)
-        self._fill_usage_result_table(period, input_list,
+        self._fill_usage_result_table(period_data, input_list,
                                       self._append_netif_send_usage_row,
                                       result_table)
 
-    def _fill_file_read_usage_result_table(self, period, files, result_table):
+    def _fill_file_read_usage_result_table(self, period_data, files,
+                                           result_table):
         input_list = sorted(files.values(),
                             key=lambda file_stats: file_stats.io.read,
                             reverse=True)
-        self._fill_usage_result_table(period, input_list,
+        self._fill_usage_result_table(period_data, input_list,
                                       self._append_file_read_usage_row,
                                       result_table)
 
-    def _fill_file_write_usage_result_table(self, period, files, result_table):
+    def _fill_file_write_usage_result_table(self, period_data, files,
+                                            result_table):
         input_list = sorted(files.values(),
                             key=lambda file_stats: file_stats.io.write,
                             reverse=True)
-        self._fill_usage_result_table(period, input_list,
+        self._fill_usage_result_table(period_data, input_list,
                                       self._append_file_write_usage_row,
                                       result_table)
 
-    def _fill_file_usage_result_tables(self, period, read_table, write_table):
-        files = self._analysis.get_files_stats(period)
-        self._fill_file_read_usage_result_table(period, files, read_table)
-        self._fill_file_write_usage_result_table(period, files, write_table)
+    def _fill_file_usage_result_tables(self, period_data, read_table,
+                                       write_table):
+        files = self._analysis.get_files_stats(period_data)
+        self._fill_file_read_usage_result_table(period_data, files,
+                                                read_table)
+        self._fill_file_write_usage_result_table(period_data, files,
+                                                 write_table)
 
-    def _get_usage_result_tables(self, period, begin, end):
+    def _get_usage_result_tables(self, period_data, begin, end):
         # create result tables
         per_proc_read_table = self._mi_create_result_table(
             self._MI_TABLE_CLASS_PER_PROCESS_TOP, begin, end, 'read')
@@ -568,23 +587,26 @@ class IoAnalysisCommand(Command):
             self._MI_TABLE_CLASS_PER_NETIF_TOP, begin, end, 'sent')
 
         # fill result tables
-        self._fill_per_process_read_usage_result_table(period,
+        self._fill_per_process_read_usage_result_table(period_data,
                                                        per_proc_read_table)
-        self._fill_per_process_write_usage_result_table(period,
+        self._fill_per_process_write_usage_result_table(period_data,
                                                         per_proc_write_table)
-        self._fill_file_usage_result_tables(period, per_file_read_table,
+        self._fill_file_usage_result_tables(period_data, per_file_read_table,
                                             per_file_write_table)
         self._fill_per_process_block_read_usage_result_table(
-            period, per_proc_block_read_table)
+            period_data, per_proc_block_read_table)
         self._fill_per_process_block_write_usage_result_table(
-            period, per_proc_block_write_table)
-        self._fill_disk_sector_usage_result_table(period,
+            period_data, per_proc_block_write_table)
+        self._fill_disk_sector_usage_result_table(period_data,
                                                   per_disk_sector_table)
-        self._fill_disk_request_usage_result_table(period,
+        self._fill_disk_request_usage_result_table(period_data,
                                                    per_disk_request_table)
-        self._fill_disk_rtps_usage_result_table(period, per_disk_rtps_table)
-        self._fill_netif_recv_usage_result_table(period, per_netif_recv_table)
-        self._fill_netif_send_usage_result_table(period, per_netif_send_table)
+        self._fill_disk_rtps_usage_result_table(period_data,
+                                                per_disk_rtps_table)
+        self._fill_netif_recv_usage_result_table(period_data,
+                                                 per_netif_recv_table)
+        self._fill_netif_send_usage_result_table(period_data,
+                                                 per_netif_send_table)
 
         return _UsageTables(
             per_proc_read=per_proc_read_table,
@@ -773,10 +795,10 @@ class IoAnalysisCommand(Command):
                 count=mi.Number(value),
             )
 
-    def _get_disk_freq_result_tables(self, period, begin, end):
+    def _get_disk_freq_result_tables(self, period_data, begin, end):
         result_tables = []
 
-        for disk in period.disks.values():
+        for disk in period_data.disks.values():
             rq_durations = [rq.duration for rq in disk.rq_list if
                             self._filter_io_request(rq)]
             subtitle = 'disk: {}'.format(disk.diskname)
@@ -788,7 +810,7 @@ class IoAnalysisCommand(Command):
 
         return result_tables
 
-    def _get_syscall_freq_result_tables(self, period, begin, end):
+    def _get_syscall_freq_result_tables(self, period_data, begin, end):
         open_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_FREQ,
                                          begin, end, 'open')
@@ -801,29 +823,29 @@ class IoAnalysisCommand(Command):
         sync_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_FREQ,
                                          begin, end, 'sync')
-        self._fill_freq_result_table([io_rq.duration for io_rq in
-                                      self._analysis.open_io_requests(period)
-                                      if self._filter_io_request(io_rq)],
-                                     open_table)
-        self._fill_freq_result_table([io_rq.duration for io_rq in
-                                      self._analysis.read_io_requests(period)
-                                      if self._filter_io_request(io_rq)],
-                                     read_table)
-        self._fill_freq_result_table([io_rq.duration for io_rq in
-                                      self._analysis.write_io_requests(period)
-                                      if self._filter_io_request(io_rq)],
-                                     write_table)
-        self._fill_freq_result_table([io_rq.duration for io_rq in
-                                      self._analysis.sync_io_requests(period)
-                                      if self._filter_io_request(io_rq)],
-                                     sync_table)
+        self._fill_freq_result_table(
+            [io_rq.duration for io_rq in
+             self._analysis.open_io_requests(period_data)
+             if self._filter_io_request(io_rq)], open_table)
+        self._fill_freq_result_table(
+            [io_rq.duration for io_rq in
+             self._analysis.read_io_requests(period_data)
+             if self._filter_io_request(io_rq)], read_table)
+        self._fill_freq_result_table(
+            [io_rq.duration for io_rq in
+             self._analysis.write_io_requests(period_data)
+             if self._filter_io_request(io_rq)], write_table)
+        self._fill_freq_result_table(
+            [io_rq.duration for io_rq in
+             self._analysis.sync_io_requests(period_data)
+             if self._filter_io_request(io_rq)], sync_table)
 
         return [open_table, read_table, write_table, sync_table]
 
-    def _get_freq_result_tables(self, period, begin, end):
-        syscall_tables = self._get_syscall_freq_result_tables(period, begin,
-                                                              end)
-        disk_tables = self._get_disk_freq_result_tables(period, begin, end)
+    def _get_freq_result_tables(self, period_data, begin, end):
+        syscall_tables = self._get_syscall_freq_result_tables(period_data,
+                                                              begin, end)
+        disk_tables = self._get_disk_freq_result_tables(period_data, begin, end)
 
         return syscall_tables + disk_tables
 
@@ -842,14 +864,14 @@ class IoAnalysisCommand(Command):
         for freq_table in freq_tables:
             self._print_one_freq(freq_table)
 
-    def _append_log_row(self, period, io_rq, result_table):
+    def _append_log_row(self, period_data, io_rq, result_table):
         if io_rq.size is None:
             size = mi.Empty()
         else:
             size = mi.Size(io_rq.size)
 
         tid = io_rq.tid
-        proc_stats = period.tids[tid]
+        proc_stats = period_data.tids[tid]
         proc_name = proc_stats.comm
 
         # TODO: handle fd_in/fd_out for RW type operations
@@ -861,7 +883,7 @@ class IoAnalysisCommand(Command):
             parent_proc = proc_stats
 
             if parent_proc.pid is not None:
-                parent_proc = period.tids[parent_proc.pid]
+                parent_proc = period_data.tids[parent_proc.pid]
 
             fd_stats = parent_proc.get_fd(io_rq.fd, io_rq.end_ts)
 
@@ -881,7 +903,7 @@ class IoAnalysisCommand(Command):
             fd=fd,
         )
 
-    def _fill_log_result_table(self, period, rq_list, sort_key, is_top,
+    def _fill_log_result_table(self, period_data, rq_list, sort_key, is_top,
                                result_table):
         if not rq_list:
             return
@@ -893,18 +915,18 @@ class IoAnalysisCommand(Command):
             if is_top and count > self._args.limit:
                 break
 
-            self._append_log_row(period, io_rq, result_table)
+            self._append_log_row(period_data, io_rq, result_table)
             count += 1
 
-    def _fill_log_result_table_from_io_requests(self, period, io_requests,
+    def _fill_log_result_table_from_io_requests(self, period_data, io_requests,
                                                 sort_key, is_top,
                                                 result_table):
         io_requests = [io_rq for io_rq in io_requests if
                        self._filter_io_request(io_rq)]
-        self._fill_log_result_table(period, io_requests, sort_key, is_top,
+        self._fill_log_result_table(period_data, io_requests, sort_key, is_top,
                                     result_table)
 
-    def _get_top_result_tables(self, period, begin, end):
+    def _get_top_result_tables(self, period_data, begin, end):
         open_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_TOP_SYSCALL,
                                          begin, end, 'open')
@@ -918,17 +940,17 @@ class IoAnalysisCommand(Command):
             self._mi_create_result_table(self._MI_TABLE_CLASS_TOP_SYSCALL,
                                          begin, end, 'sync')
         self._fill_log_result_table_from_io_requests(
-            period, self._analysis.open_io_requests(period), 'duration', True,
-            open_table)
+            period_data, self._analysis.open_io_requests(period_data),
+            'duration', True, open_table)
         self._fill_log_result_table_from_io_requests(
-            period, self._analysis.read_io_requests(period), 'duration', True,
-            read_table)
+            period_data, self._analysis.read_io_requests(period_data),
+            'duration', True, read_table)
         self._fill_log_result_table_from_io_requests(
-            period, self._analysis.write_io_requests(period), 'duration', True,
-            write_table)
+            period_data, self._analysis.write_io_requests(period_data),
+            'duration', True, write_table)
         self._fill_log_result_table_from_io_requests(
-            period, self._analysis.sync_io_requests(period), 'duration', True,
-            sync_table)
+            period_data, self._analysis.sync_io_requests(period_data),
+            'duration', True, sync_table)
 
         return [open_table, read_table, write_table, sync_table]
 
@@ -998,12 +1020,12 @@ class IoAnalysisCommand(Command):
         for table in top_tables:
             self._print_log(table)
 
-    def _get_log_result_table(self, period, begin, end):
+    def _get_log_result_table(self, period_data, begin, end):
         log_table = self._mi_create_result_table(self._MI_TABLE_CLASS_LOG,
                                                  begin, end)
         self._fill_log_result_table_from_io_requests(
-            period, self._analysis.io_requests(period), 'begin_ts', False,
-            log_table)
+            period_data, self._analysis.io_requests(period_data),
+            'begin_ts', False, log_table)
 
         return log_table
 
@@ -1043,29 +1065,29 @@ class IoAnalysisCommand(Command):
                         self._filter_io_request(io_rq)]
         self._append_latency_stats_row(obj, rq_durations, result_table)
 
-    def _get_syscall_latency_stats_result_table(self, period, begin, end):
+    def _get_syscall_latency_stats_result_table(self, period_data, begin, end):
         result_table = self._mi_create_result_table(
             self._MI_TABLE_CLASS_SYSCALL_LATENCY_STATS, begin, end)
         append_fn = self._append_latency_stats_row_from_requests
-        append_fn(mi.String('Open'), self._analysis.open_io_requests(period),
-                  result_table)
-        append_fn(mi.String('Read'), self._analysis.read_io_requests(period),
-                  result_table)
-        append_fn(mi.String('Write'), self._analysis.write_io_requests(period),
-                  result_table)
-        append_fn(mi.String('Sync'), self._analysis.sync_io_requests(period),
-                  result_table)
+        append_fn(mi.String('Open'),
+                  self._analysis.open_io_requests(period_data), result_table)
+        append_fn(mi.String('Read'),
+                  self._analysis.read_io_requests(period_data), result_table)
+        append_fn(mi.String('Write'),
+                  self._analysis.write_io_requests(period_data), result_table)
+        append_fn(mi.String('Sync'),
+                  self._analysis.sync_io_requests(period_data), result_table)
 
         return result_table
 
-    def _get_disk_latency_stats_result_table(self, period, begin, end):
-        if not period.disks:
+    def _get_disk_latency_stats_result_table(self, period_data, begin, end):
+        if not period_data.disks:
             return
 
         result_table = self._mi_create_result_table(
             self._MI_TABLE_CLASS_PART_LATENCY_STATS, begin, end)
 
-        for disk in period.disks.values():
+        for disk in period_data.disks.values():
             if disk.rq_count:
                 rq_durations = [rq.duration for rq in disk.rq_list if
                                 self._filter_io_request(rq)]
@@ -1075,10 +1097,10 @@ class IoAnalysisCommand(Command):
 
         return result_table
 
-    def _get_latency_stats_result_tables(self, period, begin, end):
-        syscall_tbl = self._get_syscall_latency_stats_result_table(period,
+    def _get_latency_stats_result_tables(self, period_data, begin, end):
+        syscall_tbl = self._get_syscall_latency_stats_result_table(period_data,
                                                                    begin, end)
-        disk_tbl = self._get_disk_latency_stats_result_table(period, begin,
+        disk_tbl = self._get_disk_latency_stats_result_table(period_data, begin,
                                                              end)
 
         return syscall_tbl, disk_tbl

--- a/lttnganalyses/cli/io.py
+++ b/lttnganalyses/cli/io.py
@@ -191,7 +191,9 @@ class IoAnalysisCommand(Command):
     _LATENCY_STATS_FORMAT = '{:<14} {:>14} {:>14} {:>14} {:>14} {:>14}'
     _SECTION_SEPARATOR_STRING = '-' * 89
 
-    def _analysis_tick(self, begin_ns, end_ns):
+    def _analysis_tick(self, period, begin_ns, end_ns):
+        if period is None:
+            return
         syscall_latency_stats_table = None
         disk_latency_stats_table = None
         freq_tables = None
@@ -201,19 +203,21 @@ class IoAnalysisCommand(Command):
 
         if self._args.stats:
             syscall_latency_stats_table, disk_latency_stats_table = \
-                self._get_latency_stats_result_tables(begin_ns, end_ns)
+                self._get_latency_stats_result_tables(period, begin_ns, end_ns)
 
         if self._args.freq:
-            freq_tables = self._get_freq_result_tables(begin_ns, end_ns)
+            freq_tables = self._get_freq_result_tables(period, begin_ns,
+                                                       end_ns)
 
         if self._args.usage:
-            usage_tables = self._get_usage_result_tables(begin_ns, end_ns)
+            usage_tables = self._get_usage_result_tables(period, begin_ns,
+                                                         end_ns)
 
         if self._args.top:
-            top_tables = self._get_top_result_tables(begin_ns, end_ns)
+            top_tables = self._get_top_result_tables(period, begin_ns, end_ns)
 
         if self._args.log:
-            log_table = self._get_log_result_table(begin_ns, end_ns)
+            log_table = self._get_log_result_table(period, begin_ns, end_ns)
 
         if self._mi_mode:
             self._mi_append_result_tables([
@@ -286,7 +290,8 @@ class IoAnalysisCommand(Command):
             io_rq.end_ts > self._analysis_conf.end_ts
         )
 
-    def _append_per_proc_read_usage_row(self, proc_stats, result_table):
+    def _append_per_proc_read_usage_row(self, period, proc_stats,
+                                        result_table):
         result_table.append_row(
             process=mi.Process(proc_stats.comm, pid=proc_stats.pid,
                                tid=proc_stats.tid),
@@ -298,7 +303,8 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_per_proc_write_usage_row(self, proc_stats, result_table):
+    def _append_per_proc_write_usage_row(self, period, proc_stats,
+                                         result_table):
         result_table.append_row(
             process=mi.Process(proc_stats.comm, pid=proc_stats.pid,
                                tid=proc_stats.tid),
@@ -310,7 +316,8 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_per_proc_block_read_usage_row(self, proc_stats, result_table):
+    def _append_per_proc_block_read_usage_row(self, period, proc_stats,
+                                              result_table):
         if proc_stats.block_io.read == 0:
             return False
 
@@ -327,7 +334,8 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_per_proc_block_write_usage_row(self, proc_stats, result_table):
+    def _append_per_proc_block_write_usage_row(self, period, proc_stats,
+                                               result_table):
         if proc_stats.block_io.write == 0:
             return False
 
@@ -344,41 +352,41 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_disk_sector_usage_row(self, disk_stats, result_table):
+    def _append_disk_sector_usage_row(self, period, disk_stats, result_table):
         if disk_stats.total_rq_sectors == 0:
             return None
 
         result_table.append_row(
-            disk=mi.Disk(disk_stats.disk_name),
+            disk=mi.Disk(disk_stats.diskname),
             count=mi.Number(disk_stats.total_rq_sectors),
         )
 
         return True
 
-    def _append_disk_request_usage_row(self, disk_stats, result_table):
+    def _append_disk_request_usage_row(self, period, disk_stats, result_table):
         if disk_stats.rq_count == 0:
             return False
 
         result_table.append_row(
-            disk=mi.Disk(disk_stats.disk_name),
+            disk=mi.Disk(disk_stats.diskname),
             count=mi.Number(disk_stats.rq_count),
         )
 
         return True
 
-    def _append_disk_rtps_usage_row(self, disk_stats, result_table):
+    def _append_disk_rtps_usage_row(self, period, disk_stats, result_table):
         if disk_stats.rq_count == 0:
             return False
 
         avg_latency = (disk_stats.total_rq_duration / disk_stats.rq_count)
         result_table.append_row(
-            disk=mi.Disk(disk_stats.disk_name),
+            disk=mi.Disk(disk_stats.diskname),
             rtps=mi.Duration(avg_latency),
         )
 
         return True
 
-    def _append_netif_recv_usage_row(self, netif_stats, result_table):
+    def _append_netif_recv_usage_row(self, period, netif_stats, result_table):
         result_table.append_row(
             netif=mi.NetIf(netif_stats.name),
             size=mi.Size(netif_stats.recv_bytes)
@@ -386,7 +394,7 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_netif_send_usage_row(self, netif_stats, result_table):
+    def _append_netif_send_usage_row(self, period, netif_stats, result_table):
         result_table.append_row(
             netif=mi.NetIf(netif_stats.name),
             size=mi.Size(netif_stats.sent_bytes)
@@ -394,20 +402,20 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _get_file_stats_fd_owners_str(self, file_stats):
+    def _get_file_stats_fd_owners_str(self, period, file_stats):
         fd_by_pid_str = ''
 
         for pid, fd in file_stats.fd_by_pid.items():
-            comm = self._analysis.tids[pid].comm
+            comm = period.tids[pid].comm
             fd_by_pid_str += 'fd %d in %s (%s) ' % (fd, comm, pid)
 
         return fd_by_pid_str
 
-    def _append_file_read_usage_row(self, file_stats, result_table):
+    def _append_file_read_usage_row(self, period, file_stats, result_table):
         if file_stats.io.read == 0:
             return False
 
-        fd_owners = self._get_file_stats_fd_owners_str(file_stats)
+        fd_owners = self._get_file_stats_fd_owners_str(period, file_stats)
         result_table.append_row(
             path=mi.Path(file_stats.filename),
             size=mi.Size(file_stats.io.read),
@@ -416,11 +424,11 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _append_file_write_usage_row(self, file_stats, result_table):
+    def _append_file_write_usage_row(self, period, file_stats, result_table):
         if file_stats.io.write == 0:
             return False
 
-        fd_owners = self._get_file_stats_fd_owners_str(file_stats)
+        fd_owners = self._get_file_stats_fd_owners_str(period, file_stats)
         result_table.append_row(
             path=mi.Path(file_stats.filename),
             size=mi.Size(file_stats.io.write),
@@ -429,110 +437,112 @@ class IoAnalysisCommand(Command):
 
         return True
 
-    def _fill_usage_result_table(self, input_list, append_row_cb,
+    def _fill_usage_result_table(self, period, input_list, append_row_cb,
                                  result_table):
         count = 0
         limit = self._args.limit
 
         for elem in input_list:
-            if append_row_cb(elem, result_table):
+            if append_row_cb(period, elem, result_table):
                 count += 1
 
                 if limit is not None and count >= limit:
                     break
 
-    def _fill_per_process_read_usage_result_table(self, result_table):
-        input_list = sorted(self._analysis.tids.values(),
+    def _fill_per_process_read_usage_result_table(self, period, result_table):
+        input_list = sorted(period.tids.values(),
                             key=operator.attrgetter('total_read'),
                             reverse=True)
-        self._fill_usage_result_table(input_list,
+        self._fill_usage_result_table(period, input_list,
                                       self._append_per_proc_read_usage_row,
                                       result_table)
 
-    def _fill_per_process_write_usage_result_table(self, result_table):
-        input_list = sorted(self._analysis.tids.values(),
+    def _fill_per_process_write_usage_result_table(self, period, result_table):
+        input_list = sorted(period.tids.values(),
                             key=operator.attrgetter('total_write'),
                             reverse=True)
-        self._fill_usage_result_table(input_list,
+        self._fill_usage_result_table(period, input_list,
                                       self._append_per_proc_write_usage_row,
                                       result_table)
 
-    def _fill_per_process_block_read_usage_result_table(self, result_table):
-        input_list = sorted(self._analysis.tids.values(),
+    def _fill_per_process_block_read_usage_result_table(self, period,
+                                                        result_table):
+        input_list = sorted(period.tids.values(),
                             key=operator.attrgetter('block_io.read'),
                             reverse=True)
         self._fill_usage_result_table(
-            input_list, self._append_per_proc_block_read_usage_row,
+            period, input_list, self._append_per_proc_block_read_usage_row,
             result_table)
 
-    def _fill_per_process_block_write_usage_result_table(self, result_table):
-        input_list = sorted(self._analysis.tids.values(),
+    def _fill_per_process_block_write_usage_result_table(self, period,
+                                                         result_table):
+        input_list = sorted(period.tids.values(),
                             key=operator.attrgetter('block_io.write'),
                             reverse=True)
         self._fill_usage_result_table(
-            input_list, self._append_per_proc_block_write_usage_row,
+            period, input_list, self._append_per_proc_block_write_usage_row,
             result_table)
 
-    def _fill_disk_sector_usage_result_table(self, result_table):
-        input_list = sorted(self._analysis.disks.values(),
+    def _fill_disk_sector_usage_result_table(self, period, result_table):
+        input_list = sorted(period.disks.values(),
                             key=operator.attrgetter('total_rq_sectors'),
                             reverse=True)
-        self._fill_usage_result_table(input_list,
+        self._fill_usage_result_table(period, input_list,
                                       self._append_disk_sector_usage_row,
                                       result_table)
 
-    def _fill_disk_request_usage_result_table(self, result_table):
-        input_list = sorted(self._analysis.disks.values(),
+    def _fill_disk_request_usage_result_table(self, period, result_table):
+        input_list = sorted(period.disks.values(),
                             key=operator.attrgetter('rq_count'),
                             reverse=True)
-        self._fill_usage_result_table(input_list,
+        self._fill_usage_result_table(period, input_list,
                                       self._append_disk_request_usage_row,
                                       result_table)
 
-    def _fill_disk_rtps_usage_result_table(self, result_table):
-        input_list = self._analysis.disks.values()
-        self._fill_usage_result_table(input_list,
+    def _fill_disk_rtps_usage_result_table(self, period, result_table):
+        input_list = period.disks.values()
+        self._fill_usage_result_table(period, input_list,
                                       self._append_disk_rtps_usage_row,
                                       result_table)
 
-    def _fill_netif_recv_usage_result_table(self, result_table):
-        input_list = sorted(self._analysis.ifaces.values(),
+    def _fill_netif_recv_usage_result_table(self, period, result_table):
+        input_list = sorted(period.ifaces.values(),
                             key=operator.attrgetter('recv_bytes'),
                             reverse=True)
-        self._fill_usage_result_table(input_list,
+        self._fill_usage_result_table(period, input_list,
                                       self._append_netif_recv_usage_row,
                                       result_table)
 
-    def _fill_netif_send_usage_result_table(self, result_table):
-        input_list = sorted(self._analysis.ifaces.values(),
+    def _fill_netif_send_usage_result_table(self, period, result_table):
+        input_list = sorted(period.ifaces.values(),
                             key=operator.attrgetter('sent_bytes'),
                             reverse=True)
-        self._fill_usage_result_table(input_list,
+        self._fill_usage_result_table(period, input_list,
                                       self._append_netif_send_usage_row,
                                       result_table)
 
-    def _fill_file_read_usage_result_table(self, files, result_table):
+    def _fill_file_read_usage_result_table(self, period, files, result_table):
         input_list = sorted(files.values(),
                             key=lambda file_stats: file_stats.io.read,
                             reverse=True)
-        self._fill_usage_result_table(input_list,
+        self._fill_usage_result_table(period, input_list,
                                       self._append_file_read_usage_row,
                                       result_table)
 
-    def _fill_file_write_usage_result_table(self, files, result_table):
+    def _fill_file_write_usage_result_table(self, period, files, result_table):
         input_list = sorted(files.values(),
                             key=lambda file_stats: file_stats.io.write,
                             reverse=True)
-        self._fill_usage_result_table(input_list,
+        self._fill_usage_result_table(period, input_list,
                                       self._append_file_write_usage_row,
                                       result_table)
 
-    def _fill_file_usage_result_tables(self, read_table, write_table):
-        files = self._analysis.get_files_stats()
-        self._fill_file_read_usage_result_table(files, read_table)
-        self._fill_file_write_usage_result_table(files, write_table)
+    def _fill_file_usage_result_tables(self, period, read_table, write_table):
+        files = self._analysis.get_files_stats(period)
+        self._fill_file_read_usage_result_table(period, files, read_table)
+        self._fill_file_write_usage_result_table(period, files, write_table)
 
-    def _get_usage_result_tables(self, begin, end):
+    def _get_usage_result_tables(self, period, begin, end):
         # create result tables
         per_proc_read_table = self._mi_create_result_table(
             self._MI_TABLE_CLASS_PER_PROCESS_TOP, begin, end, 'read')
@@ -558,19 +568,23 @@ class IoAnalysisCommand(Command):
             self._MI_TABLE_CLASS_PER_NETIF_TOP, begin, end, 'sent')
 
         # fill result tables
-        self._fill_per_process_read_usage_result_table(per_proc_read_table)
-        self._fill_per_process_write_usage_result_table(per_proc_write_table)
-        self._fill_file_usage_result_tables(per_file_read_table,
+        self._fill_per_process_read_usage_result_table(period,
+                                                       per_proc_read_table)
+        self._fill_per_process_write_usage_result_table(period,
+                                                        per_proc_write_table)
+        self._fill_file_usage_result_tables(period, per_file_read_table,
                                             per_file_write_table)
         self._fill_per_process_block_read_usage_result_table(
-            per_proc_block_read_table)
+            period, per_proc_block_read_table)
         self._fill_per_process_block_write_usage_result_table(
-            per_proc_block_write_table)
-        self._fill_disk_sector_usage_result_table(per_disk_sector_table)
-        self._fill_disk_request_usage_result_table(per_disk_request_table)
-        self._fill_disk_rtps_usage_result_table(per_disk_rtps_table)
-        self._fill_netif_recv_usage_result_table(per_netif_recv_table)
-        self._fill_netif_send_usage_result_table(per_netif_send_table)
+            period, per_proc_block_write_table)
+        self._fill_disk_sector_usage_result_table(period,
+                                                  per_disk_sector_table)
+        self._fill_disk_request_usage_result_table(period,
+                                                   per_disk_request_table)
+        self._fill_disk_rtps_usage_result_table(period, per_disk_rtps_table)
+        self._fill_netif_recv_usage_result_table(period, per_netif_recv_table)
+        self._fill_netif_send_usage_result_table(period, per_netif_send_table)
 
         return _UsageTables(
             per_proc_read=per_proc_read_table,
@@ -759,13 +773,13 @@ class IoAnalysisCommand(Command):
                 count=mi.Number(value),
             )
 
-    def _get_disk_freq_result_tables(self, begin, end):
+    def _get_disk_freq_result_tables(self, period, begin, end):
         result_tables = []
 
-        for disk in self._analysis.disks.values():
+        for disk in period.disks.values():
             rq_durations = [rq.duration for rq in disk.rq_list if
                             self._filter_io_request(rq)]
-            subtitle = 'disk: {}'.format(disk.disk_name)
+            subtitle = 'disk: {}'.format(disk.diskname)
             result_table = \
                 self._mi_create_result_table(self._MI_TABLE_CLASS_FREQ,
                                              begin, end, subtitle)
@@ -774,7 +788,7 @@ class IoAnalysisCommand(Command):
 
         return result_tables
 
-    def _get_syscall_freq_result_tables(self, begin, end):
+    def _get_syscall_freq_result_tables(self, period, begin, end):
         open_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_FREQ,
                                          begin, end, 'open')
@@ -788,27 +802,28 @@ class IoAnalysisCommand(Command):
             self._mi_create_result_table(self._MI_TABLE_CLASS_FREQ,
                                          begin, end, 'sync')
         self._fill_freq_result_table([io_rq.duration for io_rq in
-                                      self._analysis.open_io_requests if
-                                      self._filter_io_request(io_rq)],
+                                      self._analysis.open_io_requests(period)
+                                      if self._filter_io_request(io_rq)],
                                      open_table)
         self._fill_freq_result_table([io_rq.duration for io_rq in
-                                      self._analysis.read_io_requests if
-                                      self._filter_io_request(io_rq)],
+                                      self._analysis.read_io_requests(period)
+                                      if self._filter_io_request(io_rq)],
                                      read_table)
         self._fill_freq_result_table([io_rq.duration for io_rq in
-                                      self._analysis.write_io_requests if
-                                      self._filter_io_request(io_rq)],
+                                      self._analysis.write_io_requests(period)
+                                      if self._filter_io_request(io_rq)],
                                      write_table)
         self._fill_freq_result_table([io_rq.duration for io_rq in
-                                      self._analysis.sync_io_requests if
-                                      self._filter_io_request(io_rq)],
+                                      self._analysis.sync_io_requests(period)
+                                      if self._filter_io_request(io_rq)],
                                      sync_table)
 
         return [open_table, read_table, write_table, sync_table]
 
-    def _get_freq_result_tables(self, begin, end):
-        syscall_tables = self._get_syscall_freq_result_tables(begin, end)
-        disk_tables = self._get_disk_freq_result_tables(begin, end)
+    def _get_freq_result_tables(self, period, begin, end):
+        syscall_tables = self._get_syscall_freq_result_tables(period, begin,
+                                                              end)
+        disk_tables = self._get_disk_freq_result_tables(period, begin, end)
 
         return syscall_tables + disk_tables
 
@@ -827,14 +842,14 @@ class IoAnalysisCommand(Command):
         for freq_table in freq_tables:
             self._print_one_freq(freq_table)
 
-    def _append_log_row(self, io_rq, result_table):
+    def _append_log_row(self, period, io_rq, result_table):
         if io_rq.size is None:
             size = mi.Empty()
         else:
             size = mi.Size(io_rq.size)
 
         tid = io_rq.tid
-        proc_stats = self._analysis.tids[tid]
+        proc_stats = period.tids[tid]
         proc_name = proc_stats.comm
 
         # TODO: handle fd_in/fd_out for RW type operations
@@ -846,7 +861,7 @@ class IoAnalysisCommand(Command):
             parent_proc = proc_stats
 
             if parent_proc.pid is not None:
-                parent_proc = self._analysis.tids[parent_proc.pid]
+                parent_proc = period.tids[parent_proc.pid]
 
             fd_stats = parent_proc.get_fd(io_rq.fd, io_rq.end_ts)
 
@@ -866,7 +881,8 @@ class IoAnalysisCommand(Command):
             fd=fd,
         )
 
-    def _fill_log_result_table(self, rq_list, sort_key, is_top, result_table):
+    def _fill_log_result_table(self, period, rq_list, sort_key, is_top,
+                               result_table):
         if not rq_list:
             return
 
@@ -877,17 +893,18 @@ class IoAnalysisCommand(Command):
             if is_top and count > self._args.limit:
                 break
 
-            self._append_log_row(io_rq, result_table)
+            self._append_log_row(period, io_rq, result_table)
             count += 1
 
-    def _fill_log_result_table_from_io_requests(self, io_requests, sort_key,
-                                                is_top, result_table):
+    def _fill_log_result_table_from_io_requests(self, period, io_requests,
+                                                sort_key, is_top,
+                                                result_table):
         io_requests = [io_rq for io_rq in io_requests if
                        self._filter_io_request(io_rq)]
-        self._fill_log_result_table(io_requests, sort_key, is_top,
+        self._fill_log_result_table(period, io_requests, sort_key, is_top,
                                     result_table)
 
-    def _get_top_result_tables(self, begin, end):
+    def _get_top_result_tables(self, period, begin, end):
         open_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_TOP_SYSCALL,
                                          begin, end, 'open')
@@ -901,13 +918,17 @@ class IoAnalysisCommand(Command):
             self._mi_create_result_table(self._MI_TABLE_CLASS_TOP_SYSCALL,
                                          begin, end, 'sync')
         self._fill_log_result_table_from_io_requests(
-            self._analysis.open_io_requests, 'duration', True, open_table)
+            period, self._analysis.open_io_requests(period), 'duration', True,
+            open_table)
         self._fill_log_result_table_from_io_requests(
-            self._analysis.read_io_requests, 'duration', True, read_table)
+            period, self._analysis.read_io_requests(period), 'duration', True,
+            read_table)
         self._fill_log_result_table_from_io_requests(
-            self._analysis.write_io_requests, 'duration', True, write_table)
+            period, self._analysis.write_io_requests(period), 'duration', True,
+            write_table)
         self._fill_log_result_table_from_io_requests(
-            self._analysis.sync_io_requests, 'duration', True, sync_table)
+            period, self._analysis.sync_io_requests(period), 'duration', True,
+            sync_table)
 
         return [open_table, read_table, write_table, sync_table]
 
@@ -977,11 +998,12 @@ class IoAnalysisCommand(Command):
         for table in top_tables:
             self._print_log(table)
 
-    def _get_log_result_table(self, begin, end):
+    def _get_log_result_table(self, period, begin, end):
         log_table = self._mi_create_result_table(self._MI_TABLE_CLASS_LOG,
                                                  begin, end)
         self._fill_log_result_table_from_io_requests(
-            self._analysis.io_requests, 'begin_ts', False, log_table)
+            period, self._analysis.io_requests(period), 'begin_ts', False,
+            log_table)
 
         return log_table
 
@@ -1021,41 +1043,43 @@ class IoAnalysisCommand(Command):
                         self._filter_io_request(io_rq)]
         self._append_latency_stats_row(obj, rq_durations, result_table)
 
-    def _get_syscall_latency_stats_result_table(self, begin, end):
+    def _get_syscall_latency_stats_result_table(self, period, begin, end):
         result_table = self._mi_create_result_table(
             self._MI_TABLE_CLASS_SYSCALL_LATENCY_STATS, begin, end)
         append_fn = self._append_latency_stats_row_from_requests
-        append_fn(mi.String('Open'), self._analysis.open_io_requests,
+        append_fn(mi.String('Open'), self._analysis.open_io_requests(period),
                   result_table)
-        append_fn(mi.String('Read'), self._analysis.read_io_requests,
+        append_fn(mi.String('Read'), self._analysis.read_io_requests(period),
                   result_table)
-        append_fn(mi.String('Write'), self._analysis.write_io_requests,
+        append_fn(mi.String('Write'), self._analysis.write_io_requests(period),
                   result_table)
-        append_fn(mi.String('Sync'), self._analysis.sync_io_requests,
+        append_fn(mi.String('Sync'), self._analysis.sync_io_requests(period),
                   result_table)
 
         return result_table
 
-    def _get_disk_latency_stats_result_table(self, begin, end):
-        if not self._analysis.disks:
+    def _get_disk_latency_stats_result_table(self, period, begin, end):
+        if not period.disks:
             return
 
         result_table = self._mi_create_result_table(
             self._MI_TABLE_CLASS_PART_LATENCY_STATS, begin, end)
 
-        for disk in self._analysis.disks.values():
+        for disk in period.disks.values():
             if disk.rq_count:
                 rq_durations = [rq.duration for rq in disk.rq_list if
                                 self._filter_io_request(rq)]
-                disk = mi.Disk(disk.disk_name)
+                disk = mi.Disk(disk.diskname)
                 self._append_latency_stats_row(disk, rq_durations,
                                                result_table)
 
         return result_table
 
-    def _get_latency_stats_result_tables(self, begin, end):
-        syscall_tbl = self._get_syscall_latency_stats_result_table(begin, end)
-        disk_tbl = self._get_disk_latency_stats_result_table(begin, end)
+    def _get_latency_stats_result_tables(self, period, begin, end):
+        syscall_tbl = self._get_syscall_latency_stats_result_table(period,
+                                                                   begin, end)
+        disk_tbl = self._get_disk_latency_stats_result_table(period, begin,
+                                                             end)
 
         return syscall_tbl, disk_tbl
 
@@ -1083,7 +1107,7 @@ class IoAnalysisCommand(Command):
             self._print_latency_stats_row(row)
 
     def _print_disk_latency_stats(self, stats_table):
-        if not stats_table.rows:
+        if not stats_table or not stats_table.rows:
             return
 
         print('\nDisk latency statistics (usec):')
@@ -1100,7 +1124,6 @@ class IoAnalysisCommand(Command):
         self._print_disk_latency_stats(disk_latency_stats_table)
 
     def _add_arguments(self, ap):
-        Command._add_proc_filter_args(ap)
         Command._add_min_max_args(ap)
         Command._add_log_args(
             ap, help='Output the I/O requests in chronological order')

--- a/lttnganalyses/cli/irq.py
+++ b/lttnganalyses/cli/irq.py
@@ -102,18 +102,21 @@ class IrqAnalysisCommand(Command):
         ),
     ]
 
-    def _analysis_tick(self, begin_ns, end_ns):
+    def _analysis_tick(self, period, begin_ns, end_ns):
+        if period is None:
+            return
+
         log_table = None
         hard_stats_table = None
         soft_stats_table = None
         freq_tables = None
 
         if self._args.log:
-            log_table = self._get_log_result_table(begin_ns, end_ns)
+            log_table = self._get_log_result_table(period, begin_ns, end_ns)
 
         if self._args.stats or self._args.freq:
             hard_stats_table, soft_stats_table, freq_tables = \
-                self._get_stats_freq_result_tables(begin_ns, end_ns)
+                self._get_stats_freq_result_tables(period, begin_ns, end_ns)
 
         if self._mi_mode:
             self._mi_append_result_table(log_table)
@@ -164,18 +167,18 @@ class IrqAnalysisCommand(Command):
         self._mi_clear_result_tables()
         self._mi_append_result_table(summary_table)
 
-    def _get_log_result_table(self, begin_ns, end_ns):
+    def _get_log_result_table(self, period, begin_ns, end_ns):
         result_table = self._mi_create_result_table(self._MI_TABLE_CLASS_LOG,
                                                     begin_ns, end_ns)
 
-        for irq in self._analysis.irq_list:
+        for irq in period.irq_list:
             if not self._filter_irq(irq):
                 continue
 
             if type(irq) is sv.HardIRQ:
                 is_hard = True
                 raised_ts_do = mi.Empty()
-                name = self._analysis.hard_irq_stats[irq.id].name
+                name = period.hard_irq_stats[irq.id].name
             else:
                 is_hard = False
 
@@ -184,7 +187,7 @@ class IrqAnalysisCommand(Command):
                 else:
                     raised_ts_do = mi.Timestamp(irq.raise_ts)
 
-                name = self._analysis.softirq_stats[irq.id].name
+                name = period.softirq_stats[irq.id].name
 
             result_table.append_row(
                 time_range=mi.TimeRange(irq.begin_ts, irq.end_ts),
@@ -261,7 +264,7 @@ class IrqAnalysisCommand(Command):
             stdev_latency=stdev_latency,
         )
 
-    def _fill_freq_result_table(self, irq_stats, freq_table):
+    def _fill_freq_result_table(self, period, irq_stats, freq_table):
         # The number of bins for the histogram
         resolution = self._args.freq_resolution
         if self._args.min is not None:
@@ -280,7 +283,7 @@ class IrqAnalysisCommand(Command):
         # histogram's step
         if self._args.freq_uniform:
             # TODO: perform only one time
-            durations = [irq.duration for irq in self._analysis.irq_list]
+            durations = [irq.duration for irq in period.irq_list]
             min_duration, max_duration, step = \
                 self._get_uniform_freq_values(durations)
         else:
@@ -319,7 +322,7 @@ class IrqAnalysisCommand(Command):
                 count=mi.Number(count),
             )
 
-    def _fill_stats_freq_result_tables(self, begin_ns, end_ns, is_hard,
+    def _fill_stats_freq_result_tables(self, period, begin_ns, end_ns, is_hard,
                                        analysis_stats, filter_list,
                                        hard_stats_table, soft_stats_table,
                                        freq_tables):
@@ -347,7 +350,7 @@ class IrqAnalysisCommand(Command):
                 freq_table = \
                     self._mi_create_result_table(self._MI_TABLE_CLASS_FREQ,
                                                  begin_ns, end_ns, subtitle)
-                self._fill_freq_result_table(irq_stats, freq_table)
+                self._fill_freq_result_table(period, irq_stats, freq_table)
 
                 # it is possible that the frequency distribution result
                 # table is empty; we need to keep it any way because
@@ -393,10 +396,10 @@ class IrqAnalysisCommand(Command):
 
         return result_table
 
-    def _get_stats_freq_result_tables(self, begin_ns, end_ns):
-        def fill_stats_freq_result_tables(is_hard, stats, filter_list):
-            self._fill_stats_freq_result_tables(begin_ns, end_ns, is_hard,
-                                                stats, filter_list,
+    def _get_stats_freq_result_tables(self, period, begin_ns, end_ns):
+        def fill_stats_freq_result_tables(period, is_hard, stats, filter_list):
+            self._fill_stats_freq_result_tables(period, begin_ns, end_ns,
+                                                is_hard, stats, filter_list,
                                                 hard_stats_table,
                                                 soft_stats_table, freq_tables)
 
@@ -410,12 +413,12 @@ class IrqAnalysisCommand(Command):
 
         if self._args.irq_filter_list is not None or \
            self._args.softirq_filter_list is None:
-            fill_stats_freq_result_tables(True, self._analysis.hard_irq_stats,
+            fill_stats_freq_result_tables(period, True, period.hard_irq_stats,
                                           self._args.irq_filter_list)
 
         if self._args.softirq_filter_list is not None or \
            self._args.irq_filter_list is None:
-            fill_stats_freq_result_tables(False, self._analysis.softirq_stats,
+            fill_stats_freq_result_tables(period, False, period.softirq_stats,
                                           self._args.softirq_filter_list)
 
         return hard_stats_table, soft_stats_table, freq_tables
@@ -451,7 +454,8 @@ class IrqAnalysisCommand(Command):
                              '%d' % cpu_id, irqtype, irq_do.nr,
                              irq_do.name + raised_ts))
 
-    def _validate_transform_args(self, args):
+    def _validate_transform_args(self):
+        args = self._args
         args.irq_filter_list = None
         args.softirq_filter_list = None
 

--- a/lttnganalyses/cli/irq.py
+++ b/lttnganalyses/cli/irq.py
@@ -102,21 +102,24 @@ class IrqAnalysisCommand(Command):
         ),
     ]
 
-    def _analysis_tick(self, period, begin_ns, end_ns):
-        if period is None:
+    def _analysis_tick(self, period_data, end_ns):
+        if period_data is None:
             return
 
+        begin_ns = period_data.period.begin_evt.timestamp
         log_table = None
         hard_stats_table = None
         soft_stats_table = None
         freq_tables = None
 
         if self._args.log:
-            log_table = self._get_log_result_table(period, begin_ns, end_ns)
+            log_table = self._get_log_result_table(period_data,
+                                                   begin_ns, end_ns)
 
         if self._args.stats or self._args.freq:
             hard_stats_table, soft_stats_table, freq_tables = \
-                self._get_stats_freq_result_tables(period, begin_ns, end_ns)
+                self._get_stats_freq_result_tables(period_data,
+                                                   begin_ns, end_ns)
 
         if self._mi_mode:
             self._mi_append_result_table(log_table)
@@ -167,18 +170,18 @@ class IrqAnalysisCommand(Command):
         self._mi_clear_result_tables()
         self._mi_append_result_table(summary_table)
 
-    def _get_log_result_table(self, period, begin_ns, end_ns):
+    def _get_log_result_table(self, period_data, begin_ns, end_ns):
         result_table = self._mi_create_result_table(self._MI_TABLE_CLASS_LOG,
                                                     begin_ns, end_ns)
 
-        for irq in period.irq_list:
+        for irq in period_data.irq_list:
             if not self._filter_irq(irq):
                 continue
 
             if type(irq) is sv.HardIRQ:
                 is_hard = True
                 raised_ts_do = mi.Empty()
-                name = period.hard_irq_stats[irq.id].name
+                name = period_data.hard_irq_stats[irq.id].name
             else:
                 is_hard = False
 
@@ -187,7 +190,7 @@ class IrqAnalysisCommand(Command):
                 else:
                     raised_ts_do = mi.Timestamp(irq.raise_ts)
 
-                name = period.softirq_stats[irq.id].name
+                name = period_data.softirq_stats[irq.id].name
 
             result_table.append_row(
                 time_range=mi.TimeRange(irq.begin_ts, irq.end_ts),
@@ -264,7 +267,7 @@ class IrqAnalysisCommand(Command):
             stdev_latency=stdev_latency,
         )
 
-    def _fill_freq_result_table(self, period, irq_stats, freq_table):
+    def _fill_freq_result_table(self, period_data, irq_stats, freq_table):
         # The number of bins for the histogram
         resolution = self._args.freq_resolution
         if self._args.min is not None:
@@ -283,7 +286,7 @@ class IrqAnalysisCommand(Command):
         # histogram's step
         if self._args.freq_uniform:
             # TODO: perform only one time
-            durations = [irq.duration for irq in period.irq_list]
+            durations = [irq.duration for irq in period_data.irq_list]
             min_duration, max_duration, step = \
                 self._get_uniform_freq_values(durations)
         else:
@@ -322,7 +325,8 @@ class IrqAnalysisCommand(Command):
                 count=mi.Number(count),
             )
 
-    def _fill_stats_freq_result_tables(self, period, begin_ns, end_ns, is_hard,
+    def _fill_stats_freq_result_tables(self, period_data, begin_ns,
+                                       end_ns, is_hard,
                                        analysis_stats, filter_list,
                                        hard_stats_table, soft_stats_table,
                                        freq_tables):
@@ -350,7 +354,7 @@ class IrqAnalysisCommand(Command):
                 freq_table = \
                     self._mi_create_result_table(self._MI_TABLE_CLASS_FREQ,
                                                  begin_ns, end_ns, subtitle)
-                self._fill_freq_result_table(period, irq_stats, freq_table)
+                self._fill_freq_result_table(period_data, irq_stats, freq_table)
 
                 # it is possible that the frequency distribution result
                 # table is empty; we need to keep it any way because
@@ -396,9 +400,10 @@ class IrqAnalysisCommand(Command):
 
         return result_table
 
-    def _get_stats_freq_result_tables(self, period, begin_ns, end_ns):
-        def fill_stats_freq_result_tables(period, is_hard, stats, filter_list):
-            self._fill_stats_freq_result_tables(period, begin_ns, end_ns,
+    def _get_stats_freq_result_tables(self, period_data, begin_ns, end_ns):
+        def fill_stats_freq_result_tables(period_data, is_hard,
+                                          stats, filter_list):
+            self._fill_stats_freq_result_tables(period_data, begin_ns, end_ns,
                                                 is_hard, stats, filter_list,
                                                 hard_stats_table,
                                                 soft_stats_table, freq_tables)
@@ -413,12 +418,14 @@ class IrqAnalysisCommand(Command):
 
         if self._args.irq_filter_list is not None or \
            self._args.softirq_filter_list is None:
-            fill_stats_freq_result_tables(period, True, period.hard_irq_stats,
+            fill_stats_freq_result_tables(period_data, True,
+                                          period_data.hard_irq_stats,
                                           self._args.irq_filter_list)
 
         if self._args.softirq_filter_list is not None or \
            self._args.irq_filter_list is None:
-            fill_stats_freq_result_tables(period, False, period.softirq_stats,
+            fill_stats_freq_result_tables(period_data, False,
+                                          period_data.softirq_stats,
                                           self._args.softirq_filter_list)
 
         return hard_stats_table, soft_stats_table, freq_tables

--- a/lttnganalyses/cli/mi.py
+++ b/lttnganalyses/cli/mi.py
@@ -38,6 +38,7 @@ class Tags:
     STATS = 'stats'
     FREQ = 'freq'
     LOG = 'log'
+    PERIOD = 'period'
 
 
 class ColumnDescription:

--- a/lttnganalyses/cli/period_parsing.py
+++ b/lttnganalyses/cli/period_parsing.py
@@ -1,0 +1,234 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2016 - Philippe Proulx <pproulx@efficios.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pyparsing as pp
+from ..core import period
+
+
+class MalformedExpression(Exception):
+    pass
+
+
+class PeriodExists(Exception):
+    pass
+
+
+class NoSuchParent(Exception):
+    pass
+
+
+# basic expression grammar
+_e = pp.CaselessLiteral('e')
+_number = pp.Combine(pp.Word('+-' + pp.nums, pp.nums) +
+                     pp.Optional('.' + pp.Optional(pp.Word(pp.nums))) +
+                     pp.Optional(_e + pp.Word('+-' + pp.nums,
+                                 pp.nums))).setResultsName('number')
+_quoted_string = pp.QuotedString('"', '\\').setResultsName('quoted-string')
+_identifier = pp.Word(pp.alphas + '_', pp.alphanums + '_').setResultsName('id')
+_tph_scope_prefix = pp.Literal(period.DynScope.TPH.value).setResultsName(
+    'tph-scope-prefix')
+_spc_scope_prefix = pp.Literal(period.DynScope.SPC.value).setResultsName(
+    'spc-scope-prefix')
+_seh_scope_prefix = pp.Literal(period.DynScope.SEH.value).setResultsName(
+    'seh-scope-prefix')
+_sec_scope_prefix = pp.Literal(period.DynScope.SEC.value).setResultsName(
+    'sec-scope-prefix')
+_ec_scope_prefix = pp.Literal(period.DynScope.EC.value).setResultsName(
+    'ec-scope-prefix')
+_ep_scope_prefix = pp.Literal(period.DynScope.EP.value).setResultsName(
+    'ep-scope-prefix')
+_dyn_scope_prefix = pp.Group(pp.Group(_tph_scope_prefix |
+                                      _spc_scope_prefix |
+                                      _seh_scope_prefix |
+                                      _sec_scope_prefix |
+                                      _ec_scope_prefix |
+                                      _ep_scope_prefix) +
+                             '.').setResultsName('dyn-scope-prefix')
+_parent_scope_prefix = pp.Group(pp.Literal('$parent') + '.').setResultsName(
+    'parent-scope-prefix')
+_begin_scope_prefix = pp.Group(pp.Literal('$begin') + '.').setResultsName(
+    'begin-scope-prefix')
+_event_scope_prefix = pp.Group(pp.Literal('$evt') + '.').setResultsName(
+    'event-scope-prefix')
+_event_field = pp.Group(pp.Optional(_parent_scope_prefix) +
+                        pp.Optional(_begin_scope_prefix) +
+                        _event_scope_prefix +
+                        pp.Optional(_dyn_scope_prefix) +
+                        _identifier).setResultsName('event-field')
+_event_name = pp.Group(pp.Optional(_parent_scope_prefix) +
+                       pp.Optional(_begin_scope_prefix) +
+                       _event_scope_prefix +
+                       '$name').setResultsName('event-name')
+_relop = pp.Group(pp.Literal('==') | '!=' | '<=' | '>=' | '<' |
+                  '>').setResultsName('relop')
+_eqop = pp.Group(pp.Literal('==') | '!=').setResultsName('eqop')
+_name_comp_expr = pp.Group(_event_name + _eqop +
+                           _quoted_string).setResultsName('name-comp-expr')
+_number_comp_expr = pp.Group(_event_field + _relop +
+                             _number).setResultsName('number-comp-expr')
+_string_comp_expr = pp.Group(_event_field + _eqop +
+                             _quoted_string).setResultsName('string-comp-expr')
+_field_comp_expr = pp.Group(_event_field.setResultsName('lh') + _relop +
+                            _event_field.setResultsName('rh')).setResultsName(
+                                    'field-comp-expr')
+_conj_exprs = pp.delimitedList(_name_comp_expr |
+                               _number_comp_expr |
+                               _string_comp_expr |
+                               _field_comp_expr, '&&')
+_parent_name = pp.Literal('(') + _identifier + ')'
+_period_info = pp.Group(_identifier.setResultsName('name') +
+                        pp.Optional(_parent_name).setResultsName(
+                            'parent-name')).setResultsName('period-info')
+_period = pp.Optional(_period_info) + ':' + \
+          _conj_exprs.setResultsName('begin-expr') + \
+          pp.Optional(pp.Literal(':') + _conj_exprs.setResultsName('end-expr'))
+
+
+# relational operator string -> function which creates an expression
+_RELOP_TO_EXPR = {
+    '==': lambda lh, rh: period.Eq(lh, rh),
+    '!=': lambda lh, rh: period.LogicalNot(period.Eq(lh, rh)),
+    '<': lambda lh, rh: period.Lt(lh, rh),
+    '<=': lambda lh, rh: period.LtEq(lh, rh),
+    '>': lambda lh, rh: period.Gt(lh, rh),
+    '>=': lambda lh, rh: period.GtEq(lh, rh),
+}
+
+
+def _res_to_scope(res):
+    if res[-1] == '$name':
+        scope = period.EventName()
+    elif 'id' in res:
+        scope = period.EventFieldName(res['id'])
+    else:
+        assert(False)
+
+    if 'dyn-scope-prefix' in res:
+        dyn_scope = period.DynScope(res['dyn-scope-prefix'][0][0])
+        scope = period.DynamicScope(dyn_scope, scope)
+
+    scope = period.EventScope(scope)
+
+    if 'begin-scope-prefix' in res:
+        scope = period.BeginScope(scope)
+
+    if 'parent-scope-prefix' in res:
+        scope = period.ParentScope(scope)
+
+    return scope
+
+
+def _res_quoted_string_to_string_expression(res_quoted_string):
+    return period.String(str(res_quoted_string))
+
+
+def _res_number_to_number_expression(res_number):
+    return period.Number(float(str(res_number)))
+
+
+def _create_binary_op(relop, lh, rh):
+    return _RELOP_TO_EXPR[relop[0]](lh, rh)
+
+
+def _parse_results_to_expression(res_conj_exprs):
+    exprs = []
+
+    for res_expr in res_conj_exprs:
+        res_expr_name = res_expr.getName()
+
+        if res_expr_name == 'name-comp-expr':
+            ev_name_expr = _res_to_scope(res_expr['event-name'])
+            str_expr = _res_quoted_string_to_string_expression(
+                res_expr['quoted-string'])
+            expr = _create_binary_op(res_expr['eqop'], ev_name_expr, str_expr)
+        elif res_expr_name == 'number-comp-expr':
+            field_expr = _res_to_scope(res_expr['event-field'])
+            number_expr = _res_number_to_number_expression(res_expr['number'])
+            expr = _create_binary_op(res_expr['relop'], field_expr,
+                                     number_expr)
+        elif res_expr_name == 'string-comp-expr':
+            field_expr = _res_to_scope(res_expr['event-field'])
+            str_expr = _res_quoted_string_to_string_expression(
+                res_expr['quoted-string'])
+            expr = _create_binary_op(res_expr['eqop'], field_expr, str_expr)
+        elif res_expr_name == 'field-comp-expr':
+            lh_field_expr = _res_to_scope(res_expr['lh'])
+            rh_field_expr = _res_to_scope(res_expr['rh'])
+            expr = _create_binary_op(res_expr['relop'], lh_field_expr,
+                                     rh_field_expr)
+        else:
+            assert(False)
+
+        exprs.append(expr)
+
+    return period.create_conjunction_from_exprs(exprs)
+
+
+class PeriodArgParseResults:
+    def __init__(self, parent_name, period_name, begin_expr, end_expr):
+        self._parent_name = parent_name
+        self._period_name = period_name
+        self._begin_expr = begin_expr
+        self._end_expr = end_expr
+
+    @property
+    def parent_name(self):
+        return self._parent_name
+
+    @property
+    def period_name(self):
+        return self._period_name
+
+    @property
+    def begin_expr(self):
+        return self._begin_expr
+
+    @property
+    def end_expr(self):
+        return self._end_expr
+
+
+def parse_period_arg(arg):
+    try:
+        period_res = _period.parseString(arg, parseAll=True)
+    except Exception:
+        raise MalformedExpression(arg)
+
+    period_name = None
+    parent_name = None
+
+    if 'period-info' in period_res:
+        period_info_res = period_res['period-info']
+        period_name = period_info_res['name']
+
+        if 'parent-name' in period_info_res:
+            parent_name = period_info_res['parent-name']['id']
+
+    begin_expr = _parse_results_to_expression(period_res['begin-expr'])
+
+    if 'end-expr' in period_res:
+        end_expr = _parse_results_to_expression(period_res['end-expr'])
+    else:
+        end_expr = begin_expr
+
+    return PeriodArgParseResults(parent_name, period_name, begin_expr,
+                                 end_expr)

--- a/lttnganalyses/cli/period_parsing.py
+++ b/lttnganalyses/cli/period_parsing.py
@@ -28,34 +28,34 @@ class MalformedExpression(Exception):
     pass
 
 
-class PeriodExists(Exception):
-    pass
+class DuplicatePeriodCapture(Exception):
+    def __init__(self, name):
+        self._name = name
+
+    def __str__(self):
+        return 'Duplicate period capture name: "{}"'.format(self._name)
 
 
-class NoSuchParent(Exception):
-    pass
-
-
-# basic expression grammar
+# common grammar elements
 _e = pp.CaselessLiteral('e')
-_number = pp.Combine(pp.Word('+-' + pp.nums, pp.nums) +
-                     pp.Optional('.' + pp.Optional(pp.Word(pp.nums))) +
-                     pp.Optional(_e + pp.Word('+-' + pp.nums,
-                                 pp.nums))).setResultsName('number')
+_number = (pp.Combine(pp.Word('+-' + pp.nums, pp.nums) +
+                      pp.Optional('.' + pp.Optional(pp.Word(pp.nums))) +
+                      pp.Optional(_e + pp.Word('+-' + pp.nums, pp.nums)))
+           .setResultsName('number'))
 _quoted_string = pp.QuotedString('"', '\\').setResultsName('quoted-string')
 _identifier = pp.Word(pp.alphas + '_', pp.alphanums + '_').setResultsName('id')
-_tph_scope_prefix = pp.Literal(period.DynScope.TPH.value).setResultsName(
-    'tph-scope-prefix')
-_spc_scope_prefix = pp.Literal(period.DynScope.SPC.value).setResultsName(
-    'spc-scope-prefix')
-_seh_scope_prefix = pp.Literal(period.DynScope.SEH.value).setResultsName(
-    'seh-scope-prefix')
-_sec_scope_prefix = pp.Literal(period.DynScope.SEC.value).setResultsName(
-    'sec-scope-prefix')
-_ec_scope_prefix = pp.Literal(period.DynScope.EC.value).setResultsName(
-    'ec-scope-prefix')
-_ep_scope_prefix = pp.Literal(period.DynScope.EP.value).setResultsName(
-    'ep-scope-prefix')
+_tph_scope_prefix = (pp.Literal(period.DynScope.TPH.value)
+                     .setResultsName('tph-scope-prefix'))
+_spc_scope_prefix = (pp.Literal(period.DynScope.SPC.value)
+                     .setResultsName('spc-scope-prefix'))
+_seh_scope_prefix = (pp.Literal(period.DynScope.SEH.value)
+                     .setResultsName('seh-scope-prefix'))
+_sec_scope_prefix = (pp.Literal(period.DynScope.SEC.value)
+                     .setResultsName('sec-scope-prefix'))
+_ec_scope_prefix = (pp.Literal(period.DynScope.EC.value)
+                    .setResultsName('ec-scope-prefix'))
+_ep_scope_prefix = (pp.Literal(period.DynScope.EP.value)
+                    .setResultsName('ep-scope-prefix'))
 _dyn_scope_prefix = pp.Group(pp.Group(_tph_scope_prefix |
                                       _spc_scope_prefix |
                                       _seh_scope_prefix |
@@ -63,12 +63,12 @@ _dyn_scope_prefix = pp.Group(pp.Group(_tph_scope_prefix |
                                       _ec_scope_prefix |
                                       _ep_scope_prefix) +
                              '.').setResultsName('dyn-scope-prefix')
-_parent_scope_prefix = pp.Group(pp.Literal('$parent') + '.').setResultsName(
-    'parent-scope-prefix')
-_begin_scope_prefix = pp.Group(pp.Literal('$begin') + '.').setResultsName(
-    'begin-scope-prefix')
-_event_scope_prefix = pp.Group(pp.Literal('$evt') + '.').setResultsName(
-    'event-scope-prefix')
+_parent_scope_prefix = (pp.Group(pp.Literal('$parent') + '.')
+                        .setResultsName('parent-scope-prefix'))
+_begin_scope_prefix = (pp.Group(pp.Literal('$begin') + '.')
+                       .setResultsName('begin-scope-prefix'))
+_event_scope_prefix = (pp.Group(pp.Literal('$evt') + '.')
+                       .setResultsName('event-scope-prefix'))
 _event_field = pp.Group(pp.Optional(_parent_scope_prefix) +
                         pp.Optional(_begin_scope_prefix) +
                         _event_scope_prefix +
@@ -78,8 +78,8 @@ _event_name = pp.Group(pp.Optional(_parent_scope_prefix) +
                        pp.Optional(_begin_scope_prefix) +
                        _event_scope_prefix +
                        '$name').setResultsName('event-name')
-_relop = pp.Group(pp.Literal('==') | '!=' | '<=' | '>=' | '<' |
-                  '>').setResultsName('relop')
+_relop = (pp.Group(pp.Literal('==') | '!=' | '<=' | '>=' | '<' | '>')
+          .setResultsName('relop'))
 _eqop = pp.Group(pp.Literal('==') | '!=').setResultsName('eqop')
 _name_comp_expr = pp.Group(_event_name + _eqop +
                            _quoted_string).setResultsName('name-comp-expr')
@@ -87,20 +87,34 @@ _number_comp_expr = pp.Group(_event_field + _relop +
                              _number).setResultsName('number-comp-expr')
 _string_comp_expr = pp.Group(_event_field + _eqop +
                              _quoted_string).setResultsName('string-comp-expr')
-_field_comp_expr = pp.Group(_event_field.setResultsName('lh') + _relop +
-                            _event_field.setResultsName('rh')).setResultsName(
-                                    'field-comp-expr')
+_field_comp_expr = (pp.Group(_event_field.setResultsName('lh') + _relop +
+                             _event_field.setResultsName('rh'))
+                    .setResultsName('field-comp-expr'))
 _conj_exprs = pp.delimitedList(_name_comp_expr |
                                _number_comp_expr |
                                _string_comp_expr |
                                _field_comp_expr, '&&')
+
+# period definition grammar elements
 _parent_name = pp.Literal('(') + _identifier + ')'
-_period_info = pp.Group(_identifier.setResultsName('name') +
-                        pp.Optional(_parent_name).setResultsName(
-                            'parent-name')).setResultsName('period-info')
-_period = pp.Optional(_period_info) + ':' + \
-          _conj_exprs.setResultsName('begin-expr') + \
-          pp.Optional(pp.Literal(':') + _conj_exprs.setResultsName('end-expr'))
+_period_info = (pp.Group(_identifier.setResultsName('name') +
+                         (pp.Optional(_parent_name)
+                          .setResultsName('parent-name')))
+                .setResultsName('period-info'))
+_period_def = (pp.Optional(_period_info) + ':' +
+               _conj_exprs.setResultsName('begin-expr') +
+               pp.Optional(pp.Literal(':') +
+                           _conj_exprs.setResultsName('end-expr')))
+
+# period capture grammar elements
+_capture_ref = (pp.Group(pp.Optional(_identifier + '=').setResultsName('var') +
+                         (_event_name | _event_field))
+                .setResultsName('capture-ref'))
+_capture_refs = pp.delimitedList(_capture_ref, ',')
+_captures_def = (_identifier.setResultsName('name') + ':' +
+                 pp.Optional(_capture_refs.setResultsName('begin-exprs')) +
+                 pp.Optional(pp.Literal(':') +
+                             _capture_refs.setResultsName('end-exprs')))
 
 
 # relational operator string -> function which creates an expression
@@ -149,7 +163,7 @@ def _create_binary_op(relop, lh, rh):
     return _RELOP_TO_EXPR[relop[0]](lh, rh)
 
 
-def _parse_results_to_expression(res_conj_exprs):
+def _conj_exprs_results_to_expression(res_conj_exprs):
     exprs = []
 
     for res_expr in res_conj_exprs:
@@ -183,7 +197,29 @@ def _parse_results_to_expression(res_conj_exprs):
     return period.create_conjunction_from_exprs(exprs)
 
 
-class PeriodArgParseResults:
+def _capture_refs_results_to_captures_exprs(res_capture_refs):
+    captures_exprs = {}
+
+    for res_capture_ref in res_capture_refs:
+        name = None
+
+        if 'var' in res_capture_ref:
+            name = res_capture_ref['var'][0]
+
+        expr = _res_to_scope(res_capture_ref[-1])
+
+        if name is None:
+            name = str(expr)
+
+        if name in captures_exprs:
+            raise DuplicatePeriodCapture(name)
+
+        captures_exprs[name] = expr
+
+    return captures_exprs
+
+
+class PeriodDefArgParseResults:
     def __init__(self, parent_name, period_name, begin_expr, end_expr):
         self._parent_name = parent_name
         self._period_name = period_name
@@ -207,28 +243,70 @@ class PeriodArgParseResults:
         return self._end_expr
 
 
-def parse_period_arg(arg):
+class PeriodCapturesDefArgResults:
+    def __init__(self, name, begin_captures_exprs, end_captures_exprs):
+        self._name = name
+        self._begin_captures_exprs = begin_captures_exprs
+        self._end_captures_exprs = end_captures_exprs
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def begin_captures_exprs(self):
+        return self._begin_captures_exprs
+
+    @property
+    def end_captures_exprs(self):
+        return self._end_captures_exprs
+
+
+def parse_period_def_arg(arg):
     try:
-        period_res = _period.parseString(arg, parseAll=True)
+        period_def_res = _period_def.parseString(arg, parseAll=True)
     except Exception:
         raise MalformedExpression(arg)
 
     period_name = None
     parent_name = None
 
-    if 'period-info' in period_res:
-        period_info_res = period_res['period-info']
+    if 'period-info' in period_def_res:
+        period_info_res = period_def_res['period-info']
         period_name = period_info_res['name']
 
         if 'parent-name' in period_info_res:
             parent_name = period_info_res['parent-name']['id']
 
-    begin_expr = _parse_results_to_expression(period_res['begin-expr'])
+    begin_expr = _conj_exprs_results_to_expression(period_def_res['begin-expr'])
 
-    if 'end-expr' in period_res:
-        end_expr = _parse_results_to_expression(period_res['end-expr'])
+    if 'end-expr' in period_def_res:
+        end_expr = _conj_exprs_results_to_expression(period_def_res['end-expr'])
     else:
         end_expr = begin_expr
 
-    return PeriodArgParseResults(parent_name, period_name, begin_expr,
-                                 end_expr)
+    return PeriodDefArgParseResults(parent_name, period_name, begin_expr,
+                                    end_expr)
+
+
+def parse_period_captures_arg(arg):
+    try:
+        period_captures_res = _captures_def.parseString(arg, parseAll=True)
+    except Exception:
+        raise MalformedExpression(arg)
+
+
+    if 'begin-exprs' in period_captures_res:
+        begin_captures_exprs = _capture_refs_results_to_captures_exprs(
+            period_captures_res['begin-exprs'])
+    else:
+        begin_captures_exprs = {}
+
+    if 'end-exprs' in period_captures_res:
+        end_captures_exprs = _capture_refs_results_to_captures_exprs(
+            period_captures_res['end-exprs'])
+    else:
+        end_captures_exprs = {}
+
+    return PeriodCapturesDefArgResults(period_captures_res['name'],
+                                       begin_captures_exprs, end_captures_exprs)

--- a/lttnganalyses/cli/period_parsing.py
+++ b/lttnganalyses/cli/period_parsing.py
@@ -172,6 +172,17 @@ def _create_binary_op(relop, lh, rh):
     return _OP_TO_EXPR[relop[0]](lh, rh)
 
 
+def _extract_exprs(res):
+    exprs = []
+
+    for res_child in res:
+        if res_child not in ('&&', '||'):
+            expr = _expr_results_to_expression(res_child)
+            exprs.append(expr)
+
+    return exprs
+
+
 def _expr_results_to_expression(res_expr):
     # check for logical op
     if 'notop' in res_expr:
@@ -180,16 +191,14 @@ def _expr_results_to_expression(res_expr):
         return period.LogicalNot(expr)
 
     if 'andop' in res_expr:
-        lh_expr = _expr_results_to_expression(res_expr[0])
-        rh_expr = _expr_results_to_expression(res_expr[2])
+        exprs = _extract_exprs(res_expr)
 
-        return period.LogicalAnd(lh_expr, rh_expr)
+        return period.create_conjunction_from_exprs(exprs)
 
     if 'orop' in res_expr:
-        lh_expr = _expr_results_to_expression(res_expr[0])
-        rh_expr = _expr_results_to_expression(res_expr[2])
+        exprs = _extract_exprs(res_expr)
 
-        return period.LogicalOr(lh_expr, rh_expr)
+        return period.create_disjunction_from_exprs(exprs)
 
     res_expr_name = res_expr.getName()
 

--- a/lttnganalyses/cli/periods.py
+++ b/lttnganalyses/cli/periods.py
@@ -116,7 +116,7 @@ class PeriodAnalysisCommand(Command):
             return False
         return True
 
-    def _analysis_tick(self, period, begin_ns, end_ns):
+    def _analysis_tick(self, period_data, end_ns):
         # We only output something at the end of the analysis
         # not when each period finishes
         if not self._analysis.ended:
@@ -126,8 +126,6 @@ class PeriodAnalysisCommand(Command):
         # whole analysis timestamps, not the ones from the last period.
         begin_ns = self._analysis.first_event_ts
         end_ns = self._analysis.last_event_ts
-        period = None
-
         log_table = None
         top_table = None
         total_stats_table = None
@@ -136,30 +134,28 @@ class PeriodAnalysisCommand(Command):
         per_period_freq_tables = None
 
         if self._args.log:
-            log_table = self._get_log_result_table(period, begin_ns, end_ns)
+            log_table = self._get_log_result_table(begin_ns, end_ns)
 
         if self._args.top:
-            top_table = self._get_top_result_table(period, begin_ns, end_ns)
+            top_table = self._get_top_result_table(begin_ns, end_ns)
 
         if self._args.stats:
             if self._args.total:
                 total_stats_table = self._get_total_stats_result_table(
-                    period, begin_ns, end_ns)
+                    begin_ns, end_ns)
 
             if self._args.per_period:
                 per_period_stats_table = \
-                    self._get_per_period_stats_result_table(
-                        period, begin_ns, end_ns)
+                    self._get_per_period_stats_result_table(begin_ns, end_ns)
 
         if self._args.freq:
             if self._args.total:
                 total_freq_tables = self._get_total_freq_result_tables(
-                    period, begin_ns, end_ns)
+                    begin_ns, end_ns)
 
             if self._args.per_period:
                 per_period_freq_tables = \
-                    self._get_per_period_freq_result_tables(
-                        period, begin_ns, end_ns)
+                    self._get_per_period_freq_result_tables(begin_ns, end_ns)
 
         if self._mi_mode:
             if log_table:
@@ -224,7 +220,7 @@ class PeriodAnalysisCommand(Command):
             avg = 0
         return min, max, count, avg, total, filter_list
 
-    def _get_total_period_lists_stats(self, period):
+    def _get_total_period_lists_stats(self):
         if self._args.min_duration is None and \
                 self._args.max_duration is None:
             total_list = self._analysis.all_period_list
@@ -250,7 +246,7 @@ class PeriodAnalysisCommand(Command):
 
         return [total_list], total_stats
 
-    def _get_log_result_table(self, period, begin_ns, end_ns):
+    def _get_log_result_table(self, begin_ns, end_ns):
         result_table = self._mi_create_result_table(self._MI_TABLE_CLASS_LOG,
                                                     begin_ns, end_ns)
         for period_event in self._analysis.all_period_list:
@@ -265,7 +261,7 @@ class PeriodAnalysisCommand(Command):
 
         return result_table
 
-    def _get_top_result_table(self, period, begin_ns, end_ns):
+    def _get_top_result_table(self, begin_ns, end_ns):
         result_table = self._mi_create_result_table(
             self._MI_TABLE_CLASS_TOP, begin_ns, end_ns)
 
@@ -285,7 +281,7 @@ class PeriodAnalysisCommand(Command):
             )
         return result_table
 
-    def _get_total_stats_result_table(self, period, begin_ns, end_ns):
+    def _get_total_stats_result_table(self, begin_ns, end_ns):
         stats_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_TOTAL_STATS,
                                          begin_ns, end_ns)
@@ -334,7 +330,7 @@ class PeriodAnalysisCommand(Command):
 
         return stats_table
 
-    def _get_per_period_stats_result_table(self, period, begin_ns, end_ns):
+    def _get_per_period_stats_result_table(self, begin_ns, end_ns):
         stats_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_PER_PERIOD_STATS,
                                          begin_ns, end_ns)
@@ -445,9 +441,9 @@ class PeriodAnalysisCommand(Command):
                 count=mi.Number(count),
             )
 
-    def _get_total_freq_result_tables(self, period, begin_ns, end_ns):
+    def _get_total_freq_result_tables(self, begin_ns, end_ns):
         freq_tables = []
-        period_lists, period_stats = self._get_total_period_lists_stats(period)
+        period_lists, period_stats = self._get_total_period_lists_stats()
         min_duration = None
         max_duration = None
         step = None
@@ -476,7 +472,7 @@ class PeriodAnalysisCommand(Command):
 
         return freq_tables
 
-    def _get_period_lists_stats(self, period):
+    def _get_period_lists_stats(self):
         period_lists = {}
         period_stats = {}
 
@@ -510,9 +506,9 @@ class PeriodAnalysisCommand(Command):
 
         return period_lists, period_stats
 
-    def _get_per_period_freq_result_tables(self, period, begin_ns, end_ns):
+    def _get_per_period_freq_result_tables(self, begin_ns, end_ns):
         freq_tables = []
-        period_lists, period_stats = self._get_period_lists_stats(period)
+        period_lists, period_stats = self._get_period_lists_stats()
         min_duration = None
         max_duration = None
         step = None

--- a/lttnganalyses/cli/periods.py
+++ b/lttnganalyses/cli/periods.py
@@ -119,7 +119,7 @@ class PeriodAnalysisCommand(Command):
     def _analysis_tick(self, period_data, end_ns):
         # We only output something at the end of the analysis
         # not when each period finishes
-        if not self._analysis.ended:
+        if period_data is not None:
             return
 
         # Override the timestamps since we are only interested in the

--- a/lttnganalyses/cli/periods.py
+++ b/lttnganalyses/cli/periods.py
@@ -1,0 +1,725 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2016 - Julien Desfossez <jdesfossez@efficios.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import sys
+import math
+import operator
+import statistics
+import collections
+from . import mi, termgraph
+from ..core import periods
+from .command import Command
+
+
+_PeriodStats = collections.namedtuple('_PeriodStats', [
+    'count',
+    'min',
+    'max',
+    'stdev',
+    'total',
+])
+
+
+class PeriodAnalysisCommand(Command):
+    _DESC = """The periods command."""
+    _ANALYSIS_CLASS = periods.PeriodAnalysis
+    _MI_TITLE = 'Periods analysis'
+    _MI_DESCRIPTION = \
+        'Periods frequency distribution, statistics, top, and log'
+    _MI_TAGS = [mi.Tags.PERIOD, mi.Tags.STATS, mi.Tags.FREQ, mi.Tags.TOP,
+                mi.Tags.LOG]
+    _MI_TABLE_CLASS_LOG = 'log'
+    _MI_TABLE_CLASS_TOP = 'top'
+    _MI_TABLE_CLASS_TOTAL_STATS = 'total_stats'
+    _MI_TABLE_CLASS_PER_PERIOD_STATS = 'per_perio_stats'
+    _MI_TABLE_CLASS_FREQ = 'freq'
+    _MI_TABLE_CLASSES = [
+        (
+            _MI_TABLE_CLASS_LOG,
+            'Period log', [
+                ('begin_ts', 'Period begin timestamp', mi.Timestamp),
+                ('end_ts', 'Period end timestamp', mi.Timestamp),
+                ('duration', 'Period duration', mi.Duration),
+                ('name', 'Period name', mi.String),
+            ]
+        ),
+        (
+            _MI_TABLE_CLASS_TOP,
+            'Period top', [
+                ('begin_ts', 'Period begin timestamp', mi.Timestamp),
+                ('end_ts', 'Period end timestamp', mi.Timestamp),
+                ('duration', 'Period duration', mi.Duration),
+                ('name', 'Period name', mi.String),
+            ]
+        ),
+        (
+            _MI_TABLE_CLASS_TOTAL_STATS,
+            'Period statistics', [
+                ('count', 'Period count', mi.Number, 'occurences'),
+                ('min_duration', 'Minimum duration', mi.Duration),
+                ('avg_duration', 'Average duration', mi.Duration),
+                ('max_duration', 'Maximum duration', mi.Duration),
+                ('stdev_duration', 'Period duration standard deviation',
+                 mi.Duration),
+            ]
+        ),
+        (
+            _MI_TABLE_CLASS_PER_PERIOD_STATS,
+            'Period statistics', [
+                ('name', 'Period name', mi.String),
+                ('count', 'Period count', mi.Number, 'occurences'),
+                ('min_duration', 'Minimum duration', mi.Duration),
+                ('avg_duration', 'Average duration', mi.Duration),
+                ('max_duration', 'Maximum duration', mi.Duration),
+                ('stdev_duration', 'Period duration standard deviation',
+                 mi.Duration),
+            ]
+        ),
+        (
+            _MI_TABLE_CLASS_FREQ,
+            'Period duration frequency distribution', [
+                ('duration_lower', 'Duration (lower bound)', mi.Duration),
+                ('duration_upper', 'Duration (upper bound)', mi.Duration),
+                ('count', 'Period count', mi.Number, 'occurences'),
+            ]
+        ),
+    ]
+
+    def _get_count(self, period_event):
+        pass
+
+    def _filter_duration(self, period_event):
+        if self._args.min_duration is not None and \
+                period_event.duration < (self._args.min_duration * 1000):
+            return False
+        if self._args.max_duration is not None and \
+                period_event.duration > (self._args.max_duration * 1000):
+            return False
+        return True
+
+    def _analysis_tick(self, period, begin_ns, end_ns):
+        # We only output something at the end of the analysis
+        # not when each period finishes
+        if not self._analysis.ended:
+            return
+
+        # Override the timestamps since we are only interested in the
+        # whole analysis timestamps, not the ones from the last period.
+        begin_ns = self._analysis.first_event_ts
+        end_ns = self._analysis.last_event_ts
+        period = None
+
+        log_table = None
+        top_table = None
+        total_stats_table = None
+        per_period_stats_table = None
+        total_freq_tables = None
+        per_period_freq_tables = None
+
+        if self._args.log:
+            log_table = self._get_log_result_table(period, begin_ns, end_ns)
+
+        if self._args.top:
+            top_table = self._get_top_result_table(period, begin_ns, end_ns)
+
+        if self._args.stats:
+            if self._args.total:
+                total_stats_table = self._get_total_stats_result_table(
+                    period, begin_ns, end_ns)
+
+            if self._args.per_period:
+                per_period_stats_table = \
+                    self._get_per_period_stats_result_table(
+                        period, begin_ns, end_ns)
+
+        if self._args.freq:
+            if self._args.total:
+                total_freq_tables = self._get_total_freq_result_tables(
+                    period, begin_ns, end_ns)
+
+            if self._args.per_period:
+                per_period_freq_tables = \
+                    self._get_per_period_freq_result_tables(
+                        period, begin_ns, end_ns)
+
+        if self._mi_mode:
+            if log_table:
+                self._mi_append_result_table(log_table)
+
+            if top_table:
+                self._mi_append_result_table(top_table)
+
+            if total_stats_table and total_stats_table.rows:
+                self._mi_append_result_table(total_stats_table)
+
+            if per_period_stats_table and per_period_stats_table.rows:
+                self._mi_append_result_table(per_period_stats_table)
+
+            if self._args.freq:
+                if total_freq_tables:
+                    self._mi_append_result_tables(total_freq_tables)
+
+                if per_period_freq_tables:
+                    self._mi_append_result_tables(per_period_freq_tables)
+        else:
+            self._print_date(begin_ns, end_ns)
+
+            if self._args.stats:
+                if total_stats_table:
+                    self._print_total_stats(total_stats_table)
+                if per_period_stats_table:
+                    self._print_per_period_stats(per_period_stats_table)
+
+            if self._args.freq:
+                if total_freq_tables:
+                    self._print_freq(total_freq_tables)
+                if per_period_freq_tables:
+                    self._print_freq(per_period_freq_tables)
+
+            if log_table:
+                self._print_period_events(log_table)
+
+            if top_table:
+                self._print_period_events(top_table)
+
+    def _get_filtered_min_max_count_avg_total_flist(self, period_list):
+        min = None
+        max = None
+        count = 0
+        avg = 0
+        total = 0
+        filter_list = []
+        for period_event in period_list:
+            if not self._filter_duration(period_event):
+                continue
+            if min is None or min > period_event.duration:
+                min = period_event.duration
+            if max is None or max < period_event.duration:
+                max = period_event.duration
+            count += 1
+            total += period_event.duration
+            filter_list.append(period_event)
+        if count > 0:
+            avg = total/count
+        else:
+            avg = 0
+        return min, max, count, avg, total, filter_list
+
+    def _get_total_period_lists_stats(self, period):
+        if self._args.min_duration is None and \
+                self._args.max_duration is None:
+            total_list = self._analysis.all_period_list
+            stdev = self._compute_period_duration_stdev(total_list)
+            total_stats = _PeriodStats(
+                count=self._analysis.all_count,
+                min=self._analysis.all_min_duration,
+                max=self._analysis.all_max_duration,
+                stdev=stdev,
+                total=self._analysis.all_total_duration
+            )
+        else:
+            min, max, count, avg, total, total_list = \
+                self._get_filtered_min_max_count_avg_total_flist(
+                    self._analysis.all_period_list)
+            total_stats = _PeriodStats(
+                count=count,
+                min=min,
+                max=max,
+                stdev=self._compute_period_duration_stdev(total_list),
+                total=total,
+            )
+
+        return [total_list], total_stats
+
+    def _get_log_result_table(self, period, begin_ns, end_ns):
+        result_table = self._mi_create_result_table(self._MI_TABLE_CLASS_LOG,
+                                                    begin_ns, end_ns)
+        for period_event in self._analysis.all_period_list:
+            if not self._filter_duration(period_event):
+                continue
+            result_table.append_row(
+                begin_ts=mi.Timestamp(period_event.start_ts),
+                end_ts=mi.Timestamp(period_event.end_ts),
+                duration=mi.Duration(period_event.duration),
+                name=mi.String(period_event.name),
+            )
+
+        return result_table
+
+    def _get_top_result_table(self, period, begin_ns, end_ns):
+        result_table = self._mi_create_result_table(
+            self._MI_TABLE_CLASS_TOP, begin_ns, end_ns)
+
+        top_events = sorted(self._analysis.all_period_list,
+                            key=operator.attrgetter('duration'),
+                            reverse=True)
+        top_events = top_events[:self._args.limit]
+
+        for period_event in top_events:
+            if not self._filter_duration(period_event):
+                continue
+            result_table.append_row(
+                begin_ts=mi.Timestamp(period_event.start_ts),
+                end_ts=mi.Timestamp(period_event.end_ts),
+                duration=mi.Duration(period_event.duration),
+                name=mi.String(period_event.name),
+            )
+        return result_table
+
+    def _get_total_stats_result_table(self, period, begin_ns, end_ns):
+        stats_table = \
+            self._mi_create_result_table(self._MI_TABLE_CLASS_TOTAL_STATS,
+                                         begin_ns, end_ns)
+
+        if self._args.min_duration is None and \
+                self._args.max_duration is None:
+            stdev = self._compute_period_duration_stdev(
+                self._analysis.all_period_list)
+            count = self._analysis.all_count
+            min = self._analysis.all_min_duration
+            max = self._analysis.all_max_duration
+            if count == 0:
+                avg = 0
+            else:
+                avg = self._analysis.all_total_duration / \
+                        self._analysis.all_count
+        else:
+            min, max, count, avg, total, period_list = \
+                self._get_filtered_min_max_count_avg_total_flist(
+                    self._analysis.all_period_list)
+            stdev = self._compute_period_duration_stdev(period_list)
+
+        if math.isnan(stdev):
+            stdev = mi.Unknown()
+        else:
+            stdev = mi.Duration(stdev)
+
+        avg = mi.Duration(avg)
+        if min is None:
+            min = mi.Duration(0)
+        else:
+            min = mi.Duration(min)
+
+        if max is None:
+            max = mi.Duration(0)
+        else:
+            max = mi.Duration(max)
+
+        stats_table.append_row(
+            count=mi.Number(count),
+            min_duration=min,
+            avg_duration=avg,
+            max_duration=max,
+            stdev_duration=stdev,
+        )
+
+        return stats_table
+
+    def _get_per_period_stats_result_table(self, period, begin_ns, end_ns):
+        stats_table = \
+            self._mi_create_result_table(self._MI_TABLE_CLASS_PER_PERIOD_STATS,
+                                         begin_ns, end_ns)
+
+        period_stats_list = sorted(list(
+            self._analysis.all_period_stats.values()),
+            key=lambda period: period.name.lower())
+
+        for period_stats in period_stats_list:
+            if not period_stats.period_list:
+                continue
+
+            if self._args.min_duration is None and \
+                    self._args.max_duration is None:
+                stdev = self._compute_period_duration_stdev(
+                    period_stats.period_list)
+                min = period_stats.min_duration
+                max = period_stats.max_duration
+                count = period_stats.count
+                if count > 0:
+                    avg = period_stats.total_duration / \
+                            period_stats.count
+                else:
+                    avg = 0
+            else:
+                min, max, count, avg, total, period_list = \
+                    self._get_filtered_min_max_count_avg_total_flist(
+                        period_stats.period_list)
+                stdev = self._compute_period_duration_stdev(period_list)
+
+            if math.isnan(stdev):
+                stdev = mi.Unknown()
+            else:
+                stdev = mi.Duration(stdev)
+
+            stats_table.append_row(
+                name=mi.String(period_stats.name),
+                count=mi.Number(count),
+                min_duration=mi.Duration(min),
+                avg_duration=mi.Duration(avg),
+                max_duration=mi.Duration(max),
+                stdev_duration=stdev,
+            )
+
+        return stats_table
+
+    def _fill_freq_result_table(self, period_list, stats, min_duration,
+                                max_duration, step, freq_table):
+        # The number of bins for the histogram
+        resolution = self._args.freq_resolution
+
+        if not self._args.freq_uniform:
+            if self._args.min is not None:
+                min_duration = self._args.min
+            else:
+                min_duration = stats.min
+
+            if self._args.max is not None:
+                max_duration = self._args.max
+            else:
+                max_duration = stats.max
+
+            # ns to µs
+            if min_duration is None:
+                min_duration = 0
+            else:
+                min_duration /= 1000
+
+            if max_duration is None:
+                max_duration = 0
+            else:
+                max_duration /= 1000
+
+            step = (max_duration - min_duration) / resolution
+
+        if step == 0:
+            return
+
+        buckets = []
+        counts = []
+
+        for i in range(resolution):
+            buckets.append(i * step)
+            counts.append(0)
+
+        for period_event in period_list:
+            if not self._filter_duration(period_event):
+                continue
+            duration = period_event.duration / 1000
+            index = int((duration - min_duration) / step)
+
+            if index >= resolution:
+                # special case for max value: put in last bucket (includes
+                # its upper bound)
+                if duration == max_duration:
+                    counts[index - 1] += 1
+
+                continue
+
+            counts[index] += 1
+
+        for index, count in enumerate(counts):
+            lower_bound = index * step + min_duration
+            upper_bound = (index + 1) * step + min_duration
+            freq_table.append_row(
+                duration_lower=mi.Duration.from_us(lower_bound),
+                duration_upper=mi.Duration.from_us(upper_bound),
+                count=mi.Number(count),
+            )
+
+    def _get_total_freq_result_tables(self, period, begin_ns, end_ns):
+        freq_tables = []
+        period_lists, period_stats = self._get_total_period_lists_stats(period)
+        min_duration = None
+        max_duration = None
+        step = None
+        subtitle = 'All periods'
+
+        if self._args.freq_uniform:
+            durations = []
+
+            for period_list in period_lists:
+                for period_event in period_list:
+                    if not self._filter_duration(period_event):
+                        continue
+                    durations.append(period_event.duration)
+
+            min_duration, max_duration, step = \
+                self._get_uniform_freq_values(durations)
+
+        for period_list in period_lists:
+            freq_table = \
+                self._mi_create_result_table(self._MI_TABLE_CLASS_FREQ,
+                                             begin_ns, end_ns, subtitle)
+            self._fill_freq_result_table(period_list, period_stats,
+                                         min_duration, max_duration, step,
+                                         freq_table)
+            freq_tables.append(freq_table)
+
+        return freq_tables
+
+    def _get_period_lists_stats(self, period):
+        period_lists = {}
+        period_stats = {}
+
+        for period in self._analysis.all_period_stats.keys():
+            period_list = self._analysis.all_period_stats[period].period_list
+
+            if not period_list:
+                continue
+            if self._args.min_duration is None and \
+                    self._args.max_duration is None:
+                stdev = self._compute_period_duration_stdev(period_list)
+                count = len(period_list)
+                min = self._analysis.all_period_stats[period].min_duration
+                max = self._analysis.all_period_stats[period].max_duration
+                total = \
+                    self._analysis.all_period_stats[period].total_duration
+            else:
+                min, max, count, avg, total, period_list = \
+                    self._get_filtered_min_max_count_avg_total_flist(
+                        period_list)
+                stdev = self._compute_period_duration_stdev(period_list)
+
+            period_stats[period] = _PeriodStats(
+                count=count,
+                min=min,
+                max=max,
+                stdev=stdev,
+                total=total,
+            )
+            period_lists[period] = period_list
+
+        return period_lists, period_stats
+
+    def _get_per_period_freq_result_tables(self, period, begin_ns, end_ns):
+        freq_tables = []
+        period_lists, period_stats = self._get_period_lists_stats(period)
+        min_duration = None
+        max_duration = None
+        step = None
+
+        if self._args.freq_uniform:
+            durations = []
+
+            for period_list in period_lists.values():
+                for period_event in period_list:
+                    if not self._filter_duration(period_event):
+                        continue
+                    durations.append(period_event.duration)
+
+            min_duration, max_duration, step = \
+                self._get_uniform_freq_values(durations)
+
+        for period in sorted(period_stats.keys()):
+            period_list = period_lists[period]
+            stats = period_stats[period]
+            subtitle = 'Period: {}'.format(period)
+            freq_table = \
+                self._mi_create_result_table(self._MI_TABLE_CLASS_FREQ,
+                                             begin_ns, end_ns, subtitle)
+            self._fill_freq_result_table(period_list, stats,
+                                         min_duration, max_duration, step,
+                                         freq_table)
+            freq_tables.append(freq_table)
+
+        return freq_tables
+
+    def _compute_period_duration_stdev(self, period_events):
+        period_durations = []
+        for period_event in period_events:
+            if not self._filter_duration(period_event):
+                continue
+            period_durations.append(period_event.duration)
+        if len(period_durations) < 2:
+            return float('nan')
+        return statistics.stdev(period_durations)
+
+    def _print_period_events(self, result_table):
+        fmt = '[{:<18}, {:<18}] {:>15} {:<25}'
+        title_fmt = '{:<20} {:<19} {:>15} {:<25}'
+        print()
+        print(result_table.title)
+        print(title_fmt.format('Begin', 'End', 'Duration (us)', 'Name'))
+        for row in result_table.rows:
+            begin_ts = row.begin_ts.value
+            end_ts = row.end_ts.value
+            duration = row.duration.value
+            name = row.name.value
+
+            print(fmt.format(self._format_timestamp(begin_ts),
+                             self._format_timestamp(end_ts),
+                             '%0.03f' % (duration / 1000), name))
+
+    def _print_total_stats(self, stats_table):
+        row_format = '{:<12} {:<12} {:<12} {:<12} {:<12}'
+        header = row_format.format(
+            'Count', 'Min', 'Avg', 'Max', 'Stdev'
+        )
+
+        if stats_table.rows:
+            print()
+            print(stats_table.title + ' (us)')
+            print(header)
+            for row in stats_table.rows:
+                if type(row.stdev_duration) is mi.Unknown:
+                    stdev_str = '?'
+                else:
+                    stdev_str = '%0.03f' % row.stdev_duration.to_us()
+
+                row_str = row_format.format(
+                    '%d' % row.count.value,
+                    '%0.03f' % row.min_duration.to_us(),
+                    '%0.03f' % row.avg_duration.to_us(),
+                    '%0.03f' % row.max_duration.to_us(),
+                    '%s' % stdev_str,
+                )
+
+                print(row_str)
+
+    def _print_per_period_stats(self, stats_table):
+        row_format = '{:<25} {:>8}  {:>12}  {:>12}  {:>12}  {:>12}'
+        header = row_format.format(
+            'Period', 'Count', 'Min', 'Avg', 'Max', 'Stdev'
+        )
+
+        if stats_table.rows:
+            print()
+            print(stats_table.title + ' (us)')
+            print(header)
+            for row in stats_table.rows:
+                if type(row.stdev_duration) is mi.Unknown:
+                    stdev_str = '?'
+                else:
+                    stdev_str = '%0.03f' % row.stdev_duration.to_us()
+
+                row_str = row_format.format(
+                    '%s' % row.name,
+                    '%d' % row.count.value,
+                    '%0.03f' % row.min_duration.to_us(),
+                    '%0.03f' % row.avg_duration.to_us(),
+                    '%0.03f' % row.max_duration.to_us(),
+                    '%s' % stdev_str,
+                )
+
+                print(row_str)
+
+    def _print_frequency_distribution(self, freq_table):
+        title_fmt = 'Periods duration frequency distribution - {}'
+
+        graph = termgraph.FreqGraph(
+            data=freq_table.rows,
+            get_value=lambda row: row.count.value,
+            get_lower_bound=lambda row: row.duration_lower.to_us(),
+            title=title_fmt.format(freq_table.subtitle),
+            unit='µs'
+        )
+
+        graph.print_graph()
+
+    def _print_freq(self, freq_tables):
+        for freq_table in freq_tables:
+            self._print_frequency_distribution(freq_table)
+
+    def _validate_transform_args(self):
+        args = self._args
+
+        # If neither --total nor --per-period are specified, default
+        # to --per-period
+        if not (args.total or args.per_period):
+            args.per_period = True
+
+    def _add_arguments(self, ap):
+        Command._add_min_max_args(ap)
+        Command._add_freq_args(
+            ap, help='Output the frequency distribution of sched switch '
+            'durations')
+        Command._add_top_args(ap, help='Output the top sched switch durations')
+        Command._add_log_args(
+            ap, help='Output the sched switches in chronological order')
+        Command._add_stats_args(ap, help='Output sched switch statistics')
+        ap.add_argument('--total', action='store_true',
+                        help='Group all results (applies to stats and freq)')
+        ap.add_argument('--per-period', action='store_true',
+                        help='Group results per-period (applies to stats and '
+                        'freq) (default)')
+        ap.add_argument('--min-duration', type=float,
+                        help='Filter out, periods shorter that duration '
+                             '(usec)')
+        ap.add_argument('--max-duration', type=float,
+                        help='Filter out, periods longer than duration (usec)')
+
+
+def _run(mi_mode):
+    schedcmd = PeriodAnalysisCommand(mi_mode=mi_mode)
+    schedcmd.run()
+
+
+def _runstats(mi_mode):
+    sys.argv.insert(1, '--stats')
+    _run(mi_mode)
+
+
+def _runlog(mi_mode):
+    sys.argv.insert(1, '--log')
+    _run(mi_mode)
+
+
+def _runtop(mi_mode):
+    sys.argv.insert(1, '--top')
+    _run(mi_mode)
+
+
+def _runfreq(mi_mode):
+    sys.argv.insert(1, '--freq')
+    _run(mi_mode)
+
+
+def runstats():
+    _runstats(mi_mode=False)
+
+
+def runlog():
+    _runlog(mi_mode=False)
+
+
+def runtop():
+    _runtop(mi_mode=False)
+
+
+def runfreq():
+    _runfreq(mi_mode=False)
+
+
+def runstats_mi():
+    _runstats(mi_mode=True)
+
+
+def runlog_mi():
+    _runlog(mi_mode=True)
+
+
+def runtop_mi():
+    _runtop(mi_mode=True)
+
+
+def runfreq_mi():
+    _runfreq(mi_mode=True)

--- a/lttnganalyses/cli/periods.py
+++ b/lttnganalyses/cli/periods.py
@@ -60,6 +60,8 @@ class PeriodAnalysisCommand(Command):
                 ('end_ts', 'Period end timestamp', mi.Timestamp),
                 ('duration', 'Period duration', mi.Duration),
                 ('name', 'Period name', mi.String),
+                ('begin_captures', 'Begin captures', mi.String),
+                ('end_captures', 'End captures', mi.String),
             ]
         ),
         (
@@ -69,6 +71,8 @@ class PeriodAnalysisCommand(Command):
                 ('end_ts', 'Period end timestamp', mi.Timestamp),
                 ('duration', 'Period duration', mi.Duration),
                 ('name', 'Period name', mi.String),
+                ('begin_captures', 'Begin captures', mi.String),
+                ('end_captures', 'End captures', mi.String),
             ]
         ),
         (
@@ -257,6 +261,8 @@ class PeriodAnalysisCommand(Command):
                 end_ts=mi.Timestamp(period_event.end_ts),
                 duration=mi.Duration(period_event.duration),
                 name=mi.String(period_event.name),
+                begin_captures=mi.String(period_event.begin_captures),
+                end_captures=mi.String(period_event.end_captures),
             )
 
         return result_table
@@ -278,6 +284,8 @@ class PeriodAnalysisCommand(Command):
                 end_ts=mi.Timestamp(period_event.end_ts),
                 duration=mi.Duration(period_event.duration),
                 name=mi.String(period_event.name),
+                begin_captures=mi.String(period_event.begin_captures),
+                end_captures=mi.String(period_event.end_captures),
             )
         return result_table
 
@@ -550,20 +558,24 @@ class PeriodAnalysisCommand(Command):
         return statistics.stdev(period_durations)
 
     def _print_period_events(self, result_table):
-        fmt = '[{:<18}, {:<18}] {:>15} {:<25}'
-        title_fmt = '{:<20} {:<19} {:>15} {:<25}'
+        fmt = '[{:<18}, {:<18}] {:>15} {:<15} {:<45} {:<45}'
+        title_fmt = '{:<20} {:<19} {:>15} {:<15} {:<45} {:<45}'
         print()
         print(result_table.title)
-        print(title_fmt.format('Begin', 'End', 'Duration (us)', 'Name'))
+        print(title_fmt.format('Begin', 'End', 'Duration (us)', 'Name',
+                               'Begin capture', 'End capture'))
         for row in result_table.rows:
             begin_ts = row.begin_ts.value
             end_ts = row.end_ts.value
             duration = row.duration.value
             name = row.name.value
+            begin_captures = row.begin_captures.value
+            end_captures = row.end_captures.value
 
             print(fmt.format(self._format_timestamp(begin_ts),
                              self._format_timestamp(end_ts),
-                             '%0.03f' % (duration / 1000), name))
+                             '%0.03f' % (duration / 1000), name,
+                             begin_captures, end_captures))
 
     def _print_total_stats(self, stats_table):
         row_format = '{:<12} {:<12} {:<12} {:<12} {:<12}'

--- a/lttnganalyses/cli/periods.py
+++ b/lttnganalyses/cli/periods.py
@@ -50,7 +50,7 @@ class PeriodAnalysisCommand(Command):
     _MI_TABLE_CLASS_LOG = 'log'
     _MI_TABLE_CLASS_TOP = 'top'
     _MI_TABLE_CLASS_TOTAL_STATS = 'total_stats'
-    _MI_TABLE_CLASS_PER_PERIOD_STATS = 'per_perio_stats'
+    _MI_TABLE_CLASS_PER_PERIOD_STATS = 'per_period_stats'
     _MI_TABLE_CLASS_FREQ = 'freq'
     _MI_TABLE_CLASSES = [
         (
@@ -569,6 +569,8 @@ class PeriodAnalysisCommand(Command):
             end_ts = row.end_ts.value
             duration = row.duration.value
             name = row.name.value
+            if name is None:
+                name = ''
             begin_captures = row.begin_captures.value
             end_captures = row.end_captures.value
 

--- a/lttnganalyses/cli/sched.py
+++ b/lttnganalyses/cli/sched.py
@@ -127,9 +127,11 @@ class SchedAnalysisCommand(Command):
         ),
     ]
 
-    def _analysis_tick(self, period, begin_ns, end_ns):
-        if period is None:
+    def _analysis_tick(self, period_data, end_ns):
+        if period_data is None:
             return
+
+        begin_ns = period_data.period.begin_evt.timestamp
         log_table = None
         top_table = None
         total_stats_table = None
@@ -140,36 +142,38 @@ class SchedAnalysisCommand(Command):
         per_prio_freq_tables = None
 
         if self._args.log:
-            log_table = self._get_log_result_table(period, begin_ns, end_ns)
+            log_table = self._get_log_result_table(period_data,
+                                                   begin_ns, end_ns)
 
         if self._args.top:
-            top_table = self._get_top_result_table(period, begin_ns, end_ns)
+            top_table = self._get_top_result_table(period_data,
+                                                   begin_ns, end_ns)
 
         if self._args.stats:
             if self._args.total:
                 total_stats_table = self._get_total_stats_result_table(
-                    period, begin_ns, end_ns)
+                    period_data, begin_ns, end_ns)
 
             if self._args.per_tid:
                 per_tid_stats_table = self._get_per_tid_stats_result_table(
-                    period, begin_ns, end_ns)
+                    period_data, begin_ns, end_ns)
 
             if self._args.per_prio:
                 per_prio_stats_table = self._get_per_prio_stats_result_table(
-                    period, begin_ns, end_ns)
+                    period_data, begin_ns, end_ns)
 
         if self._args.freq:
             if self._args.total:
                 total_freq_tables = self._get_total_freq_result_tables(
-                    period, begin_ns, end_ns)
+                    period_data, begin_ns, end_ns)
 
             if self._args.per_tid:
                 per_tid_freq_tables = self._get_per_tid_freq_result_tables(
-                    period, begin_ns, end_ns)
+                    period_data, begin_ns, end_ns)
 
             if self._args.per_prio:
                 per_prio_freq_tables = self._get_per_prio_freq_result_tables(
-                    period, begin_ns, end_ns)
+                    period_data, begin_ns, end_ns)
 
         if self._mi_mode:
             if log_table:
@@ -221,24 +225,24 @@ class SchedAnalysisCommand(Command):
             if top_table:
                 self._print_sched_events(top_table)
 
-    def _get_total_sched_lists_stats(self, period):
-        total_list = period.sched_list
+    def _get_total_sched_lists_stats(self, period_data):
+        total_list = period_data.sched_list
         stdev = self._compute_sched_latency_stdev(total_list)
         total_stats = _SchedStats(
-            count=self._analysis.count(period),
-            min=period.min_latency,
-            max=period.max_latency,
+            count=self._analysis.count(period_data),
+            min=period_data.min_latency,
+            max=period_data.max_latency,
             stdev=stdev,
-            total=period.total_latency
+            total=period_data.total_latency
         )
 
         return [total_list], total_stats
 
-    def _get_tid_sched_lists_stats(self, period):
+    def _get_tid_sched_lists_stats(self, period_data):
         tid_sched_lists = {}
         tid_stats = {}
 
-        for sched_event in period.sched_list:
+        for sched_event in period_data.sched_list:
             tid = sched_event.wakee_proc.tid
             if tid not in tid_sched_lists:
                 tid_sched_lists[tid] = []
@@ -268,11 +272,11 @@ class SchedAnalysisCommand(Command):
 
         return tid_sched_lists, tid_stats
 
-    def _get_prio_sched_lists_stats(self, period):
+    def _get_prio_sched_lists_stats(self, period_data):
         prio_sched_lists = {}
         prio_stats = {}
 
-        for sched_event in period.sched_list:
+        for sched_event in period_data.sched_list:
             if sched_event.prio not in prio_sched_lists:
                 prio_sched_lists[sched_event.prio] = []
 
@@ -301,11 +305,11 @@ class SchedAnalysisCommand(Command):
 
         return prio_sched_lists, prio_stats
 
-    def _get_log_result_table(self, period, begin_ns, end_ns):
+    def _get_log_result_table(self, period_data, begin_ns, end_ns):
         result_table = self._mi_create_result_table(self._MI_TABLE_CLASS_LOG,
                                                     begin_ns, end_ns)
 
-        for sched_event in period.sched_list:
+        for sched_event in period_data.sched_list:
             wakee_proc = mi.Process(sched_event.wakee_proc.comm,
                                     sched_event.wakee_proc.pid,
                                     sched_event.wakee_proc.tid)
@@ -329,11 +333,11 @@ class SchedAnalysisCommand(Command):
 
         return result_table
 
-    def _get_top_result_table(self, period, begin_ns, end_ns):
+    def _get_top_result_table(self, period_data, begin_ns, end_ns):
         result_table = self._mi_create_result_table(
             self._MI_TABLE_CLASS_TOP, begin_ns, end_ns)
 
-        top_events = sorted(period.sched_list,
+        top_events = sorted(period_data.sched_list,
                             key=operator.attrgetter('latency'),
                             reverse=True)
         top_events = top_events[:self._args.limit]
@@ -362,35 +366,35 @@ class SchedAnalysisCommand(Command):
 
         return result_table
 
-    def _get_total_stats_result_table(self, period, begin_ns, end_ns):
+    def _get_total_stats_result_table(self, period_data, begin_ns, end_ns):
         stats_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_TOTAL_STATS,
                                          begin_ns, end_ns)
 
-        stdev = self._compute_sched_latency_stdev(period.sched_list)
+        stdev = self._compute_sched_latency_stdev(period_data.sched_list)
         if math.isnan(stdev):
             stdev = mi.Unknown()
         else:
             stdev = mi.Duration(stdev)
 
-        count = self._analysis.count(period)
+        count = self._analysis.count(period_data)
         if count == 0:
             avg = mi.Duration(0)
         else:
-            avg = mi.Duration(period.total_latency / count)
+            avg = mi.Duration(period_data.total_latency / count)
 
-        if period.min_latency is None:
+        if period_data.min_latency is None:
             min = mi.Duration(0)
         else:
-            min = mi.Duration(period.min_latency)
+            min = mi.Duration(period_data.min_latency)
 
-        if period.max_latency is None:
+        if period_data.max_latency is None:
             max = mi.Duration(0)
         else:
-            max = mi.Duration(period.max_latency)
+            max = mi.Duration(period_data.max_latency)
 
         stats_table.append_row(
-            count=mi.Number(self._analysis.count(period)),
+            count=mi.Number(self._analysis.count(period_data)),
             min_latency=min,
             avg_latency=avg,
             max_latency=max,
@@ -399,12 +403,12 @@ class SchedAnalysisCommand(Command):
 
         return stats_table
 
-    def _get_per_tid_stats_result_table(self, period, begin_ns, end_ns):
+    def _get_per_tid_stats_result_table(self, period_data, begin_ns, end_ns):
         stats_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_PER_TID_STATS,
                                          begin_ns, end_ns)
 
-        tid_stats_list = sorted(list(period.tids.values()),
+        tid_stats_list = sorted(list(period_data.tids.values()),
                                 key=lambda proc: proc.comm.lower())
 
         for tid_stats in tid_stats_list:
@@ -432,12 +436,12 @@ class SchedAnalysisCommand(Command):
 
         return stats_table
 
-    def _get_per_prio_stats_result_table(self, period, begin_ns, end_ns):
+    def _get_per_prio_stats_result_table(self, period_data, begin_ns, end_ns):
         stats_table = \
             self._mi_create_result_table(self._MI_TABLE_CLASS_PER_PRIO_STATS,
                                          begin_ns, end_ns)
 
-        _, prio_stats = self._get_prio_sched_lists_stats(period)
+        _, prio_stats = self._get_prio_sched_lists_stats(period_data)
 
         for prio in sorted(prio_stats):
             stats = prio_stats[prio]
@@ -600,9 +604,10 @@ class SchedAnalysisCommand(Command):
                 count=mi.Number(count),
             )
 
-    def _get_total_freq_result_tables(self, period, begin_ns, end_ns):
+    def _get_total_freq_result_tables(self, period_data, begin_ns, end_ns):
         freq_tables = []
-        sched_lists, sched_stats = self._get_total_sched_lists_stats(period)
+        sched_lists, sched_stats = self._get_total_sched_lists_stats(
+            period_data)
         min_duration = None
         max_duration = None
         step = None
@@ -626,9 +631,10 @@ class SchedAnalysisCommand(Command):
 
         return freq_tables
 
-    def _get_per_tid_freq_result_tables(self, period, begin_ns, end_ns):
+    def _get_per_tid_freq_result_tables(self, period_data, begin_ns, end_ns):
         freq_tables = []
-        tid_sched_lists, tid_stats = self._get_tid_sched_lists_stats(period)
+        tid_sched_lists, tid_stats = self._get_tid_sched_lists_stats(
+            period_data)
         min_duration = None
         max_duration = None
         step = None
@@ -655,9 +661,10 @@ class SchedAnalysisCommand(Command):
 
         return freq_tables
 
-    def _get_per_prio_freq_result_tables(self, period, begin_ns, end_ns):
+    def _get_per_prio_freq_result_tables(self, period_data, begin_ns, end_ns):
         freq_tables = []
-        prio_sched_lists, prio_stats = self._get_prio_sched_lists_stats(period)
+        prio_sched_lists, prio_stats = self._get_prio_sched_lists_stats(
+            period_data)
         min_duration = None
         max_duration = None
         step = None

--- a/lttnganalyses/cli/syscallstats.py
+++ b/lttnganalyses/cli/syscallstats.py
@@ -70,8 +70,11 @@ class SyscallsAnalysis(Command):
         ),
     ]
 
-    def _analysis_tick(self, begin_ns, end_ns):
-        total_table, per_tid_tables = self._get_result_tables(begin_ns, end_ns)
+    def _analysis_tick(self, period, begin_ns, end_ns):
+        if period is None:
+            return
+        total_table, per_tid_tables = self._get_result_tables(period,
+                                                              begin_ns, end_ns)
 
         if self._mi_mode:
             self._mi_append_result_tables(per_tid_tables)
@@ -110,12 +113,11 @@ class SyscallsAnalysis(Command):
         self._mi_clear_result_tables()
         self._mi_append_result_table(summary_table)
 
-    def _get_result_tables(self, begin_ns, end_ns):
+    def _get_result_tables(self, period, begin_ns, end_ns):
         per_tid_tables = []
         total_table = self._mi_create_result_table(self._MI_TABLE_CLASS_TOTAL,
                                                    begin_ns, end_ns)
-
-        for proc_stats in sorted(self._analysis.tids.values(),
+        for proc_stats in sorted(period.tids.values(),
                                  key=operator.attrgetter('total_syscalls'),
                                  reverse=True):
             if proc_stats.total_syscalls == 0:

--- a/lttnganalyses/cli/syscallstats.py
+++ b/lttnganalyses/cli/syscallstats.py
@@ -70,10 +70,12 @@ class SyscallsAnalysis(Command):
         ),
     ]
 
-    def _analysis_tick(self, period, begin_ns, end_ns):
-        if period is None:
+    def _analysis_tick(self, period_data, end_ns):
+        if period_data is None:
             return
-        total_table, per_tid_tables = self._get_result_tables(period,
+
+        begin_ns = period_data.period.begin_evt.timestamp
+        total_table, per_tid_tables = self._get_result_tables(period_data,
                                                               begin_ns, end_ns)
 
         if self._mi_mode:
@@ -113,11 +115,11 @@ class SyscallsAnalysis(Command):
         self._mi_clear_result_tables()
         self._mi_append_result_table(summary_table)
 
-    def _get_result_tables(self, period, begin_ns, end_ns):
+    def _get_result_tables(self, period_data, begin_ns, end_ns):
         per_tid_tables = []
         total_table = self._mi_create_result_table(self._MI_TABLE_CLASS_TOTAL,
                                                    begin_ns, end_ns)
-        for proc_stats in sorted(period.tids.values(),
+        for proc_stats in sorted(period_data.tids.values(),
                                  key=operator.attrgetter('total_syscalls'),
                                  reverse=True):
             if proc_stats.total_syscalls == 0:

--- a/lttnganalyses/common/trace_utils.py
+++ b/lttnganalyses/common/trace_utils.py
@@ -160,3 +160,44 @@ def read_babeltrace_version():
     version_string = first_line.split()[-1]
 
     return Version.new_from_string(version_string)
+
+
+def check_field_exists(handles, ev_name, field_name):
+    """Validate that a field exists in the metadata.
+
+    Args:
+        handles (TraceHandle): an array of babeltrace TraceHandle instance.
+
+        ev_name (String): the event name in which the field must exist.
+
+        field_name (String): the field that we are looking for.
+
+    Returns:
+        True if the field is found in the event, False if the field is not
+        found in the event, or if the event is not found.
+    """
+    for handle in handles.values():
+        for event in handle.events:
+            if event.name == ev_name:
+                for field in event.fields:
+                    if field.name == field_name:
+                        return True
+    return False
+
+
+def check_event_exists(handles, name):
+    """Validate that an event exists in the metadata.
+
+    Args:
+        handles (TraceHandle): an array of babeltrace TraceHandle instance.
+
+        name (String): the event name in which the field must exist.
+
+    Returns:
+        True if the event is found in the metadata, False otherwise.
+    """
+    for handle in handles.values():
+        for event in handle.events:
+            if event.name == name:
+                return True
+    return False

--- a/lttnganalyses/core/analysis.py
+++ b/lttnganalyses/core/analysis.py
@@ -102,7 +102,7 @@ class Analysis:
     # Creates the unique "definition-less" period. This is used when
     # there are no user-specified periods.
     def _create_defless_period(self, evt):
-        period = core_period.Period(None, None, evt)
+        period = core_period.Period(None, None, evt, None)
         self._on_period_begin(period)
 
     # Returns the "definition-less" period.
@@ -132,7 +132,8 @@ class Analysis:
     def _begin_period_cb(self, period_data):
         pass
 
-    def _end_period_cb(self, period_data):
+    def _end_period_cb(self, period_data, completed,
+                       begin_captures, end_captures):
         pass
 
     # This is called back by the period engine when a new period is
@@ -140,9 +141,6 @@ class Analysis:
     # that triggered the beginning of this period (the original event,
     # while `period.begin_evt` is a copy of this event).
     def _on_period_begin(self, period):
-        print('BEGIN CAPTURES')
-        print(period.begin_captures)
-
         # create the specific analysis's period data object
         period_data = self._create_period_data()
 
@@ -164,14 +162,12 @@ class Analysis:
     # Otherwise, the period finishes because one of its ancestors finishes,
     # or because the period engine user asked for it.
     def _on_period_end(self, period):
-        print('END CAPTURES')
-        print(period.end_captures)
-
         # get the period data object associated with this period object
         period_data = self._get_period_data(period)
 
         # call specific analysis's end of period callback
-        self._end_period_cb(period_data)
+        self._end_period_cb(period_data, period.completed,
+                            period.begin_captures, period.end_captures)
 
         # send tick notification to owner (CLI)
         self._send_notification_cb(AnalysisCallbackType.TICK_CB, period_data,

--- a/lttnganalyses/core/analysis.py
+++ b/lttnganalyses/core/analysis.py
@@ -140,6 +140,9 @@ class Analysis:
     # that triggered the beginning of this period (the original event,
     # while `period.begin_evt` is a copy of this event).
     def _on_period_begin(self, period):
+        print('BEGIN CAPTURES')
+        print(period.begin_captures)
+
         # create the specific analysis's period data object
         period_data = self._create_period_data()
 
@@ -161,6 +164,9 @@ class Analysis:
     # Otherwise, the period finishes because one of its ancestors finishes,
     # or because the period engine user asked for it.
     def _on_period_end(self, period):
+        print('END CAPTURES')
+        print(period.end_captures)
+
         # get the period data object associated with this period object
         period_data = self._get_period_data(period)
 

--- a/lttnganalyses/core/cputop.py
+++ b/lttnganalyses/core/cputop.py
@@ -45,7 +45,7 @@ class Cputop(Analysis):
     def _create_period_data(self):
         return _PeriodData()
 
-    def _end_period_cb(self, period_data):
+    def _end_period_cb(self, period_data, begin_captures, end_captures):
         self._compute_stats(period_data)
 
     def _compute_stats(self, period_data):
@@ -121,7 +121,8 @@ class Cputop(Analysis):
             return
 
         if next_tid not in period_data.tids:
-            period_data.tids[next_tid] = ProcessCpuStats(None, next_tid, next_comm)
+            period_data.tids[next_tid] = ProcessCpuStats(None,
+                                                         next_tid, next_comm)
             period_data.tids[next_tid].update_prio(timestamp, wakee_proc.prio)
 
         next_proc = period_data.tids[next_tid]

--- a/lttnganalyses/core/cputop.py
+++ b/lttnganalyses/core/cputop.py
@@ -45,7 +45,8 @@ class Cputop(Analysis):
     def _create_period_data(self):
         return _PeriodData()
 
-    def _end_period_cb(self, period_data, begin_captures, end_captures):
+    def _end_period_cb(self, period_data, completed, begin_captures,
+                       end_captures):
         self._compute_stats(period_data)
 
     def _compute_stats(self, period_data):

--- a/lttnganalyses/core/event.py
+++ b/lttnganalyses/core/event.py
@@ -1,0 +1,135 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2016 - Philippe Proulx <pproulx@efficios.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import babeltrace as bt
+import collections
+
+
+_CTF_SCOPES = (
+    bt.CTFScope.EVENT_FIELDS,
+    bt.CTFScope.EVENT_CONTEXT,
+    bt.CTFScope.STREAM_EVENT_CONTEXT,
+    bt.CTFScope.STREAM_EVENT_HEADER,
+    bt.CTFScope.STREAM_PACKET_CONTEXT,
+    bt.CTFScope.TRACE_PACKET_HEADER,
+)
+
+
+# This class has an interface which is compatible with the
+# babeltrace.reader.Event class. This is the result of a deep copy
+# performed by LTTng analyses.
+class Event(collections.Mapping):
+    def __init__(self, bt_ev):
+        self._copy_bt_event(bt_ev)
+
+    def _copy_bt_event(self, bt_ev):
+        self._name = bt_ev.name
+        self._cycles = bt_ev.cycles
+        self._timestamp = bt_ev.timestamp
+        self._fields = {}
+
+        for scope in _CTF_SCOPES:
+            self._fields[scope] = {}
+
+            for field_name in bt_ev.field_list_with_scope(scope):
+                field_value = bt_ev.field_with_scope(field_name, scope)
+                self._fields[scope][field_name] = field_value
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def cycles(self):
+        return self._cycles
+
+    @property
+    def timestamp(self):
+        return self._timestamp
+
+    @property
+    def handle(self):
+        raise NotImplementedError()
+
+    @property
+    def trace_collection(self):
+        raise NotImplementedError()
+
+    def _get_first_field(self, field_name):
+        for scope_fields in self._fields.values():
+            if field_name in scope_fields:
+                return scope_fields[field_name]
+
+    def field_with_scope(self, field_name, scope):
+        if scope not in self._fields:
+            raise ValueError('Invalid scope provided')
+
+        if field_name in self._fields[scope]:
+            return self._fields[scope][field_name]
+
+    def field_list_with_scope(self, scope):
+        if scope not in self._fields:
+            raise ValueError('Invalid scope provided')
+
+        return list(self._fields[scope].keys())
+
+    def __getitem__(self, field_name):
+        field = self._get_first_field(field_name)
+
+        if field is None:
+            raise KeyError(field_name)
+
+        return field
+
+    def __iter__(self):
+        for key in self.keys():
+            yield key
+
+    def __len__(self):
+        count = 0
+
+        for scope_fields in self._fields.values():
+            count += len(scope_fields)
+
+        return count
+
+    def __contains__(self, field_name):
+        return self._get_first_field(field_name) is not None
+
+    def keys(self):
+        keys = []
+
+        for scope_fields in self._fields.values():
+            keys += list(scope_fields.keys())
+
+        return keys
+
+    def get(self, field_name, default=None):
+        field = self._get_first_field(field_name)
+
+        if field is None:
+            return default
+
+        return field
+
+    def items(self):
+        raise NotImplementedError()

--- a/lttnganalyses/core/io.py
+++ b/lttnganalyses/core/io.py
@@ -244,7 +244,8 @@ class IoAnalysis(Analysis):
         fd = kwargs['fd']
 
         if tid not in period_data.tids:
-            period_data.tids[tid] = ProcessIOStats.new_from_process(parent_proc)
+            period_data.tids[tid] = ProcessIOStats.new_from_process(
+                    parent_proc)
 
         parent_stats = period_data.tids[tid]
         if fd not in parent_stats.fds:
@@ -265,9 +266,15 @@ class IoAnalysis(Analysis):
         last_fd.close_ts = timestamp
 
     def _process_update_fd(self, period_data, **kwargs):
+        timestamp = kwargs['timestamp']
         parent_proc = kwargs['parent_proc']
         tid = parent_proc.tid
         fd = kwargs['fd']
+
+        if fd not in period_data.tids[tid].fds:
+            period_data.tids[tid].fds[fd] = []
+            period_data.tids[tid].fds[fd].append(
+                FDStats.new_from_fd(parent_proc.fds[fd], timestamp))
 
         new_filename = parent_proc.fds[fd].filename
         fd_list = period_data.tids[tid].fds[fd]

--- a/lttnganalyses/core/io.py
+++ b/lttnganalyses/core/io.py
@@ -303,6 +303,8 @@ class IoAnalysis(Analysis):
 
         parent_stats = self.tids[tid]
         last_fd = parent_stats.get_fd(fd)
+        if last_fd is None:
+            return
         last_fd.close_ts = timestamp
 
     def _process_update_fd(self, **kwargs):
@@ -405,9 +407,11 @@ class ProcessIOStats(stats.Process):
         if req.errno is not None:
             return
 
-        if req.fd is not None:
-            self.get_fd(req.fd).update_stats(req)
-        elif isinstance(req, sv.ReadWriteIORequest):
+        if req.fd is None or self.get_fd(req.fd) is None:
+            return
+
+        self.get_fd(req.fd).update_stats(req)
+        if isinstance(req, sv.ReadWriteIORequest):
             if req.fd_in is not None:
                 self.get_fd(req.fd_in).update_stats(req)
 

--- a/lttnganalyses/core/io.py
+++ b/lttnganalyses/core/io.py
@@ -160,10 +160,10 @@ class IoAnalysis(Analysis):
         proc = kwargs['proc']
         disk = kwargs['disk']
 
-        if req.dev not in period.disks:
-            period.disks[req.dev] = DiskStats.new_from_disk(disk)
+        if disk.dev not in period.disks:
+            period.disks[disk.dev] = DiskStats.new_from_disk(disk)
 
-        period.disks[req.dev].update_stats(req)
+        period.disks[disk.dev].update_stats(req)
 
         if proc is not None:
             if proc.tid not in period.tids:

--- a/lttnganalyses/core/io.py
+++ b/lttnganalyses/core/io.py
@@ -21,8 +21,15 @@
 # SOFTWARE.
 
 from . import stats
-from .analysis import Analysis
+from .analysis import Analysis, PeriodData
 from ..linuxautomaton import sv
+
+
+class _PeriodData(PeriodData):
+    def __init__(self):
+        self.disks = {}
+        self.ifaces = {}
+        self.tids = {}
 
 
 class IoAnalysis(Analysis):
@@ -35,78 +42,56 @@ class IoAnalysis(Analysis):
             'create_fd': self._process_create_fd,
             'close_fd': self._process_close_fd,
             'update_fd': self._process_update_fd,
-            'create_parent_proc': self._process_create_parent_proc
+            'create_parent_proc': self._process_create_parent_proc,
+            'lttng_statedump_block_device': self._process_statedump_block
         }
 
-        event_cbs = {
-            'lttng_statedump_block_device':
-            self._process_lttng_statedump_block_device
-        }
-
-        super().__init__(state, conf)
-        self._state.register_notification_cbs(notification_cbs)
-        self._register_cbs(event_cbs)
-
-        self.disks = {}
-        self.ifaces = {}
-        self.tids = {}
+        super().__init__(state, conf, notification_cbs)
+        if conf.cpu_list is not None:
+            print('Warning: cpu filter not enabled on I/O analysis')
 
     def process_event(self, ev):
         super().process_event(ev)
         self._process_event_cb(ev)
 
-    def reset(self):
-        for dev in self.disks:
-            self.disks[dev].reset()
-
-        for name in self.ifaces:
-            self.ifaces[name].reset()
-
-        for tid in self.tids:
-            self.tids[tid].reset()
+    def _create_period_data(self):
+        return _PeriodData()
 
     @property
-    def disk_io_requests(self):
-        for disk in self.disks.values():
+    def disk_io_requests(self, period):
+        for disk in period.disks.values():
             for io_rq in disk.rq_list:
                 yield io_rq
 
-    @property
-    def io_requests(self):
-        return self._get_io_requests()
+    def io_requests(self, period):
+        return self._get_io_requests(period)
 
-    @property
-    def open_io_requests(self):
-        return self._get_io_requests(sv.IORequest.OP_OPEN)
+    def open_io_requests(self, period):
+        return self._get_io_requests(period, sv.IORequest.OP_OPEN)
 
-    @property
-    def read_io_requests(self):
-        return self._get_io_requests(sv.IORequest.OP_READ)
+    def read_io_requests(self, period):
+        return self._get_io_requests(period, sv.IORequest.OP_READ)
 
-    @property
-    def write_io_requests(self):
-        return self._get_io_requests(sv.IORequest.OP_WRITE)
+    def write_io_requests(self, period):
+        return self._get_io_requests(period, sv.IORequest.OP_WRITE)
 
-    @property
-    def close_io_requests(self):
-        return self._get_io_requests(sv.IORequest.OP_CLOSE)
+    def close_io_requests(self, period):
+        return self._get_io_requests(period, sv.IORequest.OP_CLOSE)
 
-    @property
-    def sync_io_requests(self):
-        return self._get_io_requests(sv.IORequest.OP_SYNC)
+    def sync_io_requests(self, period):
+        return self._get_io_requests(period, sv.IORequest.OP_SYNC)
 
-    @property
-    def read_write_io_requests(self):
-        return self._get_io_requests(sv.IORequest.OP_READ_WRITE)
+    def read_write_io_requests(self, period):
+        return self._get_io_requests(period, sv.IORequest.OP_READ_WRITE)
 
-    def _get_io_requests(self, io_operation=None):
+    def _get_io_requests(self, period, io_operation=None):
         """Create a generator of syscall io requests by operation.
 
         Args:
             io_operation (IORequest.OP_*, optional): The operation of
             the io_requests to return. Return all IO requests if None.
         """
-        for proc in self.tids.values():
+        for proc in period.tids.values():
             for io_rq in proc.rq_list:
                 if isinstance(io_rq, sv.BlockIORequest):
                     continue
@@ -116,10 +101,10 @@ class IoAnalysis(Analysis):
                                                         io_rq.operation):
                     yield io_rq
 
-    def get_files_stats(self):
+    def get_files_stats(self, period):
         files_stats = {}
 
-        for proc_stats in self.tids.values():
+        for proc_stats in period.tids.values():
             for fd_list in proc_stats.fds.values():
                 for fd_stats in fd_list:
                     filename = fd_stats.filename
@@ -150,84 +135,56 @@ class IoAnalysis(Analysis):
             for fd in toremove:
                 del proc.fds[fd]
 
-    def _process_net_dev_xmit(self, **kwargs):
+    def _process_net_dev_xmit(self, period, **kwargs):
         name = kwargs['iface_name']
         sent_bytes = kwargs['sent_bytes']
-        cpu = kwargs['cpu_id']
 
-        if not self._filter_cpu(cpu):
-            return
+        if name not in period.ifaces:
+            period.ifaces[name] = IfaceStats(name)
 
-        if name not in self.ifaces:
-            self.ifaces[name] = IfaceStats(name)
+        period.ifaces[name].sent_packets += 1
+        period.ifaces[name].sent_bytes += sent_bytes
 
-        self.ifaces[name].sent_packets += 1
-        self.ifaces[name].sent_bytes += sent_bytes
-
-    def _process_netif_receive_skb(self, **kwargs):
+    def _process_netif_receive_skb(self, period, **kwargs):
         name = kwargs['iface_name']
         recv_bytes = kwargs['recv_bytes']
-        cpu = kwargs['cpu_id']
 
-        if not self._filter_cpu(cpu):
-            return
+        if name not in period.ifaces:
+            period.ifaces[name] = IfaceStats(name)
 
-        if name not in self.ifaces:
-            self.ifaces[name] = IfaceStats(name)
+        period.ifaces[name].recv_packets += 1
+        period.ifaces[name].recv_bytes += recv_bytes
 
-        self.ifaces[name].recv_packets += 1
-        self.ifaces[name].recv_bytes += recv_bytes
-
-    def _process_block_rq_complete(self, **kwargs):
+    def _process_block_rq_complete(self, period, **kwargs):
         req = kwargs['req']
         proc = kwargs['proc']
-        cpu = kwargs['cpu_id']
+        disk = kwargs['disk']
 
-        if not self._filter_process(proc):
-            return
-        if not self._filter_cpu(cpu):
-            return
+        if req.dev not in period.disks:
+            period.disks[req.dev] = DiskStats.new_from_disk(disk)
 
-        if req.dev not in self.disks:
-            self.disks[req.dev] = DiskStats(req.dev)
-
-        self.disks[req.dev].update_stats(req)
+        period.disks[req.dev].update_stats(req)
 
         if proc is not None:
-            if proc.tid not in self.tids:
-                self.tids[proc.tid] = ProcessIOStats.new_from_process(proc)
+            if proc.tid not in period.tids:
+                period.tids[proc.tid] = ProcessIOStats.new_from_process(proc)
 
-            self.tids[proc.tid].update_block_stats(req)
+            period.tids[proc.tid].update_block_stats(req)
 
-    def _process_lttng_statedump_block_device(self, event):
-        dev = event['dev']
-        disk_name = event['diskname']
-
-        if dev not in self.disks:
-            self.disks[dev] = DiskStats(dev, disk_name)
-        else:
-            self.disks[dev].disk_name = disk_name
-
-    def _process_io_rq_exit(self, **kwargs):
+    def _process_io_rq_exit(self, period, **kwargs):
         proc = kwargs['proc']
         parent_proc = kwargs['parent_proc']
         io_rq = kwargs['io_rq']
-        cpu = kwargs['cpu_id']
 
-        if not self._filter_process(parent_proc):
-            return
-        if not self._filter_cpu(cpu):
-            return
+        if proc.tid not in period.tids:
+            period.tids[proc.tid] = ProcessIOStats.new_from_process(proc)
 
-        if proc.tid not in self.tids:
-            self.tids[proc.tid] = ProcessIOStats.new_from_process(proc)
-
-        if parent_proc.tid not in self.tids:
-            self.tids[parent_proc.tid] = (
+        if parent_proc.tid not in period.tids:
+            period.tids[parent_proc.tid] = (
                 ProcessIOStats.new_from_process(parent_proc))
 
-        proc_stats = self.tids[proc.tid]
-        parent_stats = self.tids[parent_proc.tid]
+        proc_stats = period.tids[proc.tid]
+        parent_stats = period.tids[parent_proc.tid]
 
         fd_types = {}
         if io_rq.errno is None:
@@ -248,72 +205,65 @@ class IoAnalysis(Analysis):
         if parent_stats.comm != parent_proc.comm:
             parent_stats.comm = parent_proc.comm
 
-    def _process_create_parent_proc(self, **kwargs):
+    def _process_create_parent_proc(self, period, **kwargs):
         proc = kwargs['proc']
         parent_proc = kwargs['parent_proc']
 
-        if not self._filter_process(parent_proc):
-            return
+        if proc.tid not in period.tids:
+            period.tids[proc.tid] = ProcessIOStats.new_from_process(proc)
 
-        if proc.tid not in self.tids:
-            self.tids[proc.tid] = ProcessIOStats.new_from_process(proc)
-
-        if parent_proc.tid not in self.tids:
-            self.tids[parent_proc.tid] = (
+        if parent_proc.tid not in period.tids:
+            period.tids[parent_proc.tid] = (
                 ProcessIOStats.new_from_process(parent_proc))
 
-        proc_stats = self.tids[proc.tid]
-        parent_stats = self.tids[parent_proc.tid]
+        proc_stats = period.tids[proc.tid]
+        parent_stats = period.tids[parent_proc.tid]
 
         proc_stats.pid = parent_stats.tid
         IoAnalysis._assign_fds_to_parent(proc_stats, parent_stats)
 
-    def _process_create_fd(self, **kwargs):
+    def _process_statedump_block(self, period, **kwargs):
+        dev = kwargs['dev']
+        diskname = kwargs['diskname']
+        if dev not in period.disks:
+            period.disks[dev] = DiskStats(dev, diskname)
+        else:
+            period.disks[dev].diskname = diskname
+
+    def _process_create_fd(self, period, **kwargs):
         timestamp = kwargs['timestamp']
         parent_proc = kwargs['parent_proc']
         tid = parent_proc.tid
-        cpu = kwargs['cpu_id']
         fd = kwargs['fd']
 
-        if not self._filter_process(parent_proc):
-            return
-        if not self._filter_cpu(cpu):
-            return
+        if tid not in period.tids:
+            period.tids[tid] = ProcessIOStats.new_from_process(parent_proc)
 
-        if tid not in self.tids:
-            self.tids[tid] = ProcessIOStats.new_from_process(parent_proc)
-
-        parent_stats = self.tids[tid]
+        parent_stats = period.tids[tid]
         if fd not in parent_stats.fds:
             parent_stats.fds[fd] = []
         parent_stats.fds[fd].append(FDStats.new_from_fd(parent_proc.fds[fd],
                                                         timestamp))
 
-    def _process_close_fd(self, **kwargs):
+    def _process_close_fd(self, period, **kwargs):
         timestamp = kwargs['timestamp']
         parent_proc = kwargs['parent_proc']
         tid = parent_proc.tid
-        cpu = kwargs['cpu_id']
         fd = kwargs['fd']
 
-        if not self._filter_process(parent_proc):
-            return
-        if not self._filter_cpu(cpu):
-            return
-
-        parent_stats = self.tids[tid]
+        parent_stats = period.tids[tid]
         last_fd = parent_stats.get_fd(fd)
         if last_fd is None:
             return
         last_fd.close_ts = timestamp
 
-    def _process_update_fd(self, **kwargs):
+    def _process_update_fd(self, period, **kwargs):
         parent_proc = kwargs['parent_proc']
         tid = parent_proc.tid
         fd = kwargs['fd']
 
         new_filename = parent_proc.fds[fd].filename
-        fd_list = self.tids[tid].fds[fd]
+        fd_list = period.tids[tid].fds[fd]
         fd_list[-1].filename = new_filename
 
 
@@ -321,18 +271,22 @@ class DiskStats():
     MINORBITS = 20
     MINORMASK = ((1 << MINORBITS) - 1)
 
-    def __init__(self, dev, disk_name=None):
+    def __init__(self, dev, diskname=None):
         self.dev = dev
-        if disk_name is not None:
-            self.disk_name = disk_name
+        if diskname is not None:
+            self.diskname = diskname
         else:
-            self.disk_name = DiskStats._get_name_from_dev(dev)
+            self.diskname = DiskStats._get_name_from_dev(dev)
 
         self.min_rq_duration = None
         self.max_rq_duration = None
         self.total_rq_sectors = 0
         self.total_rq_duration = 0
         self.rq_list = []
+
+    @classmethod
+    def new_from_disk(cls, disk):
+        return cls(disk.dev, disk.diskname)
 
     @property
     def rq_count(self):

--- a/lttnganalyses/core/io.py
+++ b/lttnganalyses/core/io.py
@@ -190,8 +190,14 @@ class IoAnalysis(Analysis):
         if io_rq.errno is None:
             if io_rq.operation == sv.IORequest.OP_READ or \
                io_rq.operation == sv.IORequest.OP_WRITE:
+                if parent_stats.get_fd(io_rq.fd) is None:
+                    return
                 fd_types['fd'] = parent_stats.get_fd(io_rq.fd).fd_type
             elif io_rq.operation == sv.IORequest.OP_READ_WRITE:
+                if parent_stats.get_fd(io_rq.fd_in) is None:
+                    return
+                if parent_stats.get_fd(io_rq.fd_out) is None:
+                    return
                 fd_types['fd_in'] = parent_stats.get_fd(io_rq.fd_in).fd_type
                 fd_types['fd_out'] = parent_stats.get_fd(io_rq.fd_out).fd_type
 

--- a/lttnganalyses/core/irq.py
+++ b/lttnganalyses/core/irq.py
@@ -20,7 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .analysis import Analysis
+from .analysis import Analysis, PeriodData
+
+
+class _PeriodData(PeriodData):
+    def __init__(self):
+        # Indexed by irq 'id' (irq or vec)
+        self.hard_irq_stats = {}
+        self.softirq_stats = {}
+        # Log of individual interrupts
+        self.irq_list = []
 
 
 class IrqAnalysis(Analysis):
@@ -30,32 +39,20 @@ class IrqAnalysis(Analysis):
             'irq_handler_exit': self._process_irq_handler_exit,
             'softirq_exit': self._process_softirq_exit
         }
+        super().__init__(state, conf, notification_cbs)
 
-        super().__init__(state, conf)
-        self._state.register_notification_cbs(notification_cbs)
+    def _create_period_data(self):
+        return _PeriodData()
 
-        # Indexed by irq 'id' (irq or vec)
-        self.hard_irq_stats = {}
-        self.softirq_stats = {}
-        # Log of individual interrupts
-        self.irq_list = []
-
-    def reset(self):
-        self.irq_list = []
-        for id in self.hard_irq_stats:
-            self.hard_irq_stats[id].reset()
-        for id in self.softirq_stats:
-            self.softirq_stats[id].reset()
-
-    def _process_irq_handler_entry(self, **kwargs):
+    def _process_irq_handler_entry(self, period, **kwargs):
         id = kwargs['id']
         name = kwargs['irq_name']
-        if id not in self.hard_irq_stats:
-            self.hard_irq_stats[id] = HardIrqStats(name)
-        elif name not in self.hard_irq_stats[id].names:
-            self.hard_irq_stats[id].names.append(name)
+        if id not in period.hard_irq_stats:
+            period.hard_irq_stats[id] = HardIrqStats(name)
+        elif name not in period.hard_irq_stats[id].names:
+            period.hard_irq_stats[id].names.append(name)
 
-    def _process_irq_handler_exit(self, **kwargs):
+    def _process_irq_handler_exit(self, period, **kwargs):
         irq = kwargs['hard_irq']
 
         if not self._filter_cpu(irq.cpu_id):
@@ -68,13 +65,13 @@ class IrqAnalysis(Analysis):
            irq.duration > self._conf.max_duration:
             return
 
-        self.irq_list.append(irq)
-        if irq.id not in self.hard_irq_stats:
-            self.hard_irq_stats[irq.id] = HardIrqStats()
+        period.irq_list.append(irq)
+        if irq.id not in period.hard_irq_stats:
+            period.hard_irq_stats[irq.id] = HardIrqStats()
 
-        self.hard_irq_stats[irq.id].update_stats(irq)
+        period.hard_irq_stats[irq.id].update_stats(irq)
 
-    def _process_softirq_exit(self, **kwargs):
+    def _process_softirq_exit(self, period, **kwargs):
         irq = kwargs['softirq']
 
         if not self._filter_cpu(irq.cpu_id):
@@ -87,12 +84,12 @@ class IrqAnalysis(Analysis):
            irq.duration > self._conf.max_duration:
             return
 
-        self.irq_list.append(irq)
-        if irq.id not in self.softirq_stats:
+        period.irq_list.append(irq)
+        if irq.id not in period.softirq_stats:
             name = SoftIrqStats.names[irq.id]
-            self.softirq_stats[irq.id] = SoftIrqStats(name)
+            period.softirq_stats[irq.id] = SoftIrqStats(name)
 
-        self.softirq_stats[irq.id].update_stats(irq)
+        period.softirq_stats[irq.id].update_stats(irq)
 
 
 class IrqStats():

--- a/lttnganalyses/core/irq.py
+++ b/lttnganalyses/core/irq.py
@@ -44,15 +44,15 @@ class IrqAnalysis(Analysis):
     def _create_period_data(self):
         return _PeriodData()
 
-    def _process_irq_handler_entry(self, period, **kwargs):
+    def _process_irq_handler_entry(self, period_data, **kwargs):
         id = kwargs['id']
         name = kwargs['irq_name']
-        if id not in period.hard_irq_stats:
-            period.hard_irq_stats[id] = HardIrqStats(name)
-        elif name not in period.hard_irq_stats[id].names:
-            period.hard_irq_stats[id].names.append(name)
+        if id not in period_data.hard_irq_stats:
+            period_data.hard_irq_stats[id] = HardIrqStats(name)
+        elif name not in period_data.hard_irq_stats[id].names:
+            period_data.hard_irq_stats[id].names.append(name)
 
-    def _process_irq_handler_exit(self, period, **kwargs):
+    def _process_irq_handler_exit(self, period_data, **kwargs):
         irq = kwargs['hard_irq']
 
         if not self._filter_cpu(irq.cpu_id):
@@ -65,13 +65,13 @@ class IrqAnalysis(Analysis):
            irq.duration > self._conf.max_duration:
             return
 
-        period.irq_list.append(irq)
-        if irq.id not in period.hard_irq_stats:
-            period.hard_irq_stats[irq.id] = HardIrqStats()
+        period_data.irq_list.append(irq)
+        if irq.id not in period_data.hard_irq_stats:
+            period_data.hard_irq_stats[irq.id] = HardIrqStats()
 
-        period.hard_irq_stats[irq.id].update_stats(irq)
+        period_data.hard_irq_stats[irq.id].update_stats(irq)
 
-    def _process_softirq_exit(self, period, **kwargs):
+    def _process_softirq_exit(self, period_data, **kwargs):
         irq = kwargs['softirq']
 
         if not self._filter_cpu(irq.cpu_id):
@@ -84,12 +84,12 @@ class IrqAnalysis(Analysis):
            irq.duration > self._conf.max_duration:
             return
 
-        period.irq_list.append(irq)
-        if irq.id not in period.softirq_stats:
+        period_data.irq_list.append(irq)
+        if irq.id not in period_data.softirq_stats:
             name = SoftIrqStats.names[irq.id]
-            period.softirq_stats[irq.id] = SoftIrqStats(name)
+            period_data.softirq_stats[irq.id] = SoftIrqStats(name)
 
-        period.softirq_stats[irq.id].update_stats(irq)
+        period_data.softirq_stats[irq.id].update_stats(irq)
 
 
 class IrqStats():

--- a/lttnganalyses/core/memtop.py
+++ b/lttnganalyses/core/memtop.py
@@ -21,7 +21,12 @@
 # SOFTWARE.
 
 from . import stats
-from .analysis import Analysis
+from .analysis import Analysis, PeriodData
+
+
+class _PeriodData(PeriodData):
+    def __init__(self):
+        self.tids = {}
 
 
 class Memtop(Analysis):
@@ -30,17 +35,12 @@ class Memtop(Analysis):
             'tid_page_alloc': self._process_tid_page_alloc,
             'tid_page_free': self._process_tid_page_free
         }
+        super().__init__(state, conf, notification_cbs)
 
-        super().__init__(state, conf)
-        self._state.register_notification_cbs(notification_cbs)
+    def _create_period_data(self):
+        return _PeriodData()
 
-        self.tids = {}
-
-    def reset(self):
-        for tid in self.tids:
-            self.tids[tid].reset()
-
-    def _process_tid_page_alloc(self, **kwargs):
+    def _process_tid_page_alloc(self, period, **kwargs):
         cpu_id = kwargs['cpu_id']
         proc = kwargs['proc']
 
@@ -50,12 +50,12 @@ class Memtop(Analysis):
             return
 
         tid = proc.tid
-        if tid not in self.tids:
-            self.tids[tid] = ProcessMemStats.new_from_process(proc)
+        if tid not in period.tids:
+            period.tids[tid] = ProcessMemStats.new_from_process(proc)
 
-        self.tids[tid].allocated_pages += 1
+        period.tids[tid].allocated_pages += 1
 
-    def _process_tid_page_free(self, **kwargs):
+    def _process_tid_page_free(self, period, **kwargs):
         cpu_id = kwargs['cpu_id']
         proc = kwargs['proc']
 
@@ -65,10 +65,10 @@ class Memtop(Analysis):
             return
 
         tid = proc.tid
-        if tid not in self.tids:
-            self.tids[tid] = ProcessMemStats.new_from_process(proc)
+        if tid not in period.tids:
+            period.tids[tid] = ProcessMemStats.new_from_process(proc)
 
-        self.tids[tid].freed_pages += 1
+        period.tids[tid].freed_pages += 1
 
 
 class ProcessMemStats(stats.Process):

--- a/lttnganalyses/core/memtop.py
+++ b/lttnganalyses/core/memtop.py
@@ -37,10 +37,10 @@ class Memtop(Analysis):
         }
         super().__init__(state, conf, notification_cbs)
 
-    def _create_period_data(self):
+    def _create_period_data_data(self):
         return _PeriodData()
 
-    def _process_tid_page_alloc(self, period, **kwargs):
+    def _process_tid_page_alloc(self, period_data, **kwargs):
         cpu_id = kwargs['cpu_id']
         proc = kwargs['proc']
 
@@ -50,12 +50,12 @@ class Memtop(Analysis):
             return
 
         tid = proc.tid
-        if tid not in period.tids:
-            period.tids[tid] = ProcessMemStats.new_from_process(proc)
+        if tid not in period_data.tids:
+            period_data.tids[tid] = ProcessMemStats.new_from_process(proc)
 
-        period.tids[tid].allocated_pages += 1
+        period_data.tids[tid].allocated_pages += 1
 
-    def _process_tid_page_free(self, period, **kwargs):
+    def _process_tid_page_free(self, period_data, **kwargs):
         cpu_id = kwargs['cpu_id']
         proc = kwargs['proc']
 
@@ -65,10 +65,10 @@ class Memtop(Analysis):
             return
 
         tid = proc.tid
-        if tid not in period.tids:
-            period.tids[tid] = ProcessMemStats.new_from_process(proc)
+        if tid not in period_data.tids:
+            period_data.tids[tid] = ProcessMemStats.new_from_process(proc)
 
-        period.tids[tid].freed_pages += 1
+        period_data.tids[tid].freed_pages += 1
 
 
 class ProcessMemStats(stats.Process):

--- a/lttnganalyses/core/period.py
+++ b/lttnganalyses/core/period.py
@@ -626,7 +626,7 @@ class PeriodEngine:
         periods_to_add = set()
 
         for child_period_def in child_period_defs:
-            match_context = _MatchContext(evt, evt, None)
+            match_context = self._create_begin_match_context(parent_period, evt)
 
             if _expr_matches(child_period_def.begin_expr, match_context):
                 # match! add period
@@ -651,6 +651,14 @@ class PeriodEngine:
     def _process_event_begin(self, evt):
         defs = self._registry.root_period_defs
         self._process_event_add_periods(None, self._root_periods, defs, evt)
+
+    def _create_begin_match_context(self, parent_period, evt):
+        parent_begin_evt = None
+
+        if parent_period is not None:
+            parent_begin_evt = parent_period.begin_evt
+
+        return _MatchContext(evt, evt, parent_begin_evt)
 
     def _create_end_match_context(self, period, evt):
         parent_begin_evt = None

--- a/lttnganalyses/core/period.py
+++ b/lttnganalyses/core/period.py
@@ -1,0 +1,607 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2016 - Philippe Proulx <pproulx@efficios.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from . import event as core_event
+from functools import partial
+import babeltrace as bt
+import enum
+
+
+class InvalidPeriodDefinition(Exception):
+    pass
+
+
+# period definition registry, owner of the whole tree of periods
+class PeriodDefinitionRegistry:
+    def __init__(self):
+        self._root_period_defs = set()
+        self._named_period_defs = {}
+
+    def has_period_def(self, name):
+        return name in self._named_period_defs
+
+    def add_period_def(self, parent_name, period_name, begin_expr, end_expr):
+        # validate unique period name (if named)
+        if self.has_period_def(period_name):
+            raise InvalidPeriodDefinition('Cannot redefine period "{}"'.format(
+                period_name))
+
+        # validate that parent exists if it's set
+        if parent_name is not None and not self.has_period_def(parent_name):
+            fmt = 'Cannot find parent period named "{}" (as parent of ' \
+                  'period "{}")'
+            msg = fmt.format(parent_name, period_name)
+            raise InvalidPeriodDefinition(msg)
+
+        # create period, and associate parent and children
+        parent = None
+
+        if parent_name is not None:
+            parent = self.get_period_def(parent_name)
+
+        period_def = PeriodDefinition(parent, period_name, begin_expr,
+                                      end_expr)
+
+        if parent is not None:
+            parent.children.add(period_def)
+
+        # validate new period definition
+        PeriodDefinitionValidator(period_def)
+
+        if period_def.parent is None:
+            self._root_period_defs.add(period_def)
+
+        if period_def.name is not None:
+            self._named_period_defs[period_def.name] = period_def
+
+    def get_period_def(self, name):
+        return self._named_period_defs.get(name)
+
+    @property
+    def root_period_defs(self):
+        for period_def in self._root_period_defs:
+            yield period_def
+
+    @property
+    def is_empty(self):
+        return len(self._root_period_defs) == 0 and \
+                len(self._named_period_defs) == 0
+
+
+# definition of a period
+class PeriodDefinition:
+    def __init__(self, parent, name, begin_expr, end_expr):
+        self._parent = parent
+        self._children = set()
+        self._name = name
+        self._begin_expr = begin_expr
+        self._end_expr = end_expr
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def parent(self):
+        return self._parent
+
+    @property
+    def begin_expr(self):
+        return self._begin_expr
+
+    @property
+    def end_expr(self):
+        return self._end_expr
+
+    @property
+    def children(self):
+        return self._children
+
+
+class _Expression:
+    pass
+
+
+class _BinaryExpression(_Expression):
+    def __init__(self, lh_expr, rh_expr):
+        self._lh_expr = lh_expr
+        self._rh_expr = rh_expr
+
+    @property
+    def lh_expr(self):
+        return self._lh_expr
+
+    @property
+    def rh_expr(self):
+        return self._rh_expr
+
+
+class _UnaryExpression(_Expression):
+    def __init__(self, expr):
+        self._expr = expr
+
+    @property
+    def expr(self):
+        return self._expr
+
+
+class LogicalNot(_UnaryExpression):
+    def __repr__(self):
+        return '(!{})'.format(self.expr)
+
+
+class LogicalAnd(_BinaryExpression):
+    def __repr__(self):
+        return '({} && {})'.format(self.lh_expr, self.rh_expr)
+
+
+class Eq(_BinaryExpression):
+    def __repr__(self):
+        return '({} == {})'.format(self.lh_expr, self.rh_expr)
+
+
+class Lt(_BinaryExpression):
+    def __repr__(self):
+        return '({} < {})'.format(self.lh_expr, self.rh_expr)
+
+
+class LtEq(_BinaryExpression):
+    def __repr__(self):
+        return '({} <= {})'.format(self.lh_expr, self.rh_expr)
+
+
+class Gt(_BinaryExpression):
+    def __repr__(self):
+        return '({} > {})'.format(self.lh_expr, self.rh_expr)
+
+
+class GtEq(_BinaryExpression):
+    def __repr__(self):
+        return '({} >= {})'.format(self.lh_expr, self.rh_expr)
+
+
+class Number(_Expression):
+    def __init__(self, value):
+        self._value = value
+
+    @property
+    def value(self):
+        return self._value
+
+    def __repr__(self):
+        return '({})'.format(self.value)
+
+
+class String(_Expression):
+    def __init__(self, value):
+        self._value = value
+
+    @property
+    def value(self):
+        return self._value
+
+    def __repr__(self):
+        return '("{}")'.format(self.value)
+
+
+@enum.unique
+class DynScope(enum.Enum):
+    AUTO = 'auto'
+    TPH = '$pkt_header'
+    SPC = '$pkt_ctx'
+    SEH = '$header'
+    SEC = '$stream_ctx'
+    EC = '$ctx'
+    EP = '$payload'
+
+
+class _SingleChildNode(_Expression):
+    def __init__(self, child):
+        self._child = child
+
+    @property
+    def child(self):
+        return self._child
+
+
+class ParentScope(_SingleChildNode):
+    def __repr__(self):
+        return '$parent.{}'.format(self.child)
+
+
+class BeginScope(_SingleChildNode):
+    def __repr__(self):
+        return '$begin.{}'.format(self.child)
+
+
+class EventScope(_SingleChildNode):
+    def __repr__(self):
+        return '$evt.{}'.format(self.child)
+
+
+class DynamicScope(_SingleChildNode):
+    def __init__(self, dyn_scope, child):
+        super().__init__(child)
+        self._dyn_scope = dyn_scope
+
+    @property
+    def dyn_scope(self):
+        return self._dyn_scope
+
+    def __repr__(self):
+        if self._dyn_scope == DynScope.AUTO:
+            return repr(self.child)
+
+        return '{}.{}'.format(self.dyn_scope.value, self.child)
+
+
+class EventFieldName(_Expression):
+    def __init__(self, name):
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+
+    def __repr__(self):
+        return self._name
+
+
+class EventName(_Expression):
+    def __repr__(self):
+        return '$name'
+
+
+class IllegalExpression(Exception):
+    pass
+
+
+class PeriodDefinitionValidator:
+    def __init__(self, period_def):
+        self._period_def = period_def
+        self._validate_expr_cbs = {
+            LogicalNot: self._validate_not,
+            LogicalAnd: self._validate_and_expr,
+            Eq: self._validate_comp,
+            Lt: self._validate_comp,
+            LtEq: self._validate_comp,
+            Gt: self._validate_comp,
+            GtEq: self._validate_comp,
+            ParentScope: self._validate_parent_scope,
+        }
+        self._validate_expr(period_def.begin_expr)
+        self._validate_expr(period_def.end_expr)
+
+    def _validate_not(self, not_expr):
+        self._validate_expr(not_expr.expr)
+
+    def _validate_and_expr(self, and_expr):
+        self._validate_expr(and_expr.lh_expr)
+        self._validate_expr(and_expr.rh_expr)
+
+    def _validate_parent_scope(self, scope):
+        if self._period_def.parent is None:
+            raise IllegalExpression('Cannot refer to parent context without '
+                                    'a named parent period')
+
+        if type(scope.child) is not BeginScope:
+            raise IllegalExpression('Must refer to the begin context in a '
+                                    'parent context')
+
+        self._validate_expr(scope.child)
+
+    def _validate_comp(self, comp_expr):
+        self._validate_expr(comp_expr.lh_expr)
+        self._validate_expr(comp_expr.rh_expr)
+
+    def _validate_expr(self, expr):
+        if type(expr) in self._validate_expr_cbs:
+            self._validate_expr_cbs[type(expr)](expr)
+
+
+class _MatchContext:
+    def __init__(self, evt, begin_evt, parent_begin_evt):
+        self._evt = evt
+        self._begin_evt = begin_evt
+        self._parent_begin_evt = parent_begin_evt
+
+    @property
+    def evt(self):
+        return self._evt
+
+    @property
+    def begin_evt(self):
+        return self._begin_evt
+
+    @property
+    def parent_begin_evt(self):
+        return self._parent_begin_evt
+
+
+_DYN_SCOPE_TO_BT_CTF_SCOPE = {
+    DynScope.TPH: bt.CTFScope.TRACE_PACKET_HEADER,
+    DynScope.SPC: bt.CTFScope.STREAM_PACKET_CONTEXT,
+    DynScope.SEH: bt.CTFScope.STREAM_EVENT_HEADER,
+    DynScope.SEC: bt.CTFScope.STREAM_EVENT_CONTEXT,
+    DynScope.EC: bt.CTFScope.EVENT_CONTEXT,
+    DynScope.EP: bt.CTFScope.EVENT_FIELDS,
+}
+
+
+class _Matcher:
+    def __init__(self, expr, match_context):
+        self._match_context = match_context
+        self._expr_matchers = {
+            LogicalAnd: self._and_expr_matches,
+            LogicalNot: self._not_expr_matches,
+            Eq: partial(self._comp_expr_matches, lambda lh, rh: lh == rh),
+            Lt: partial(self._comp_expr_matches, lambda lh, rh: lh < rh),
+            LtEq: partial(self._comp_expr_matches, lambda lh, rh: lh <= rh),
+            Gt: partial(self._comp_expr_matches, lambda lh, rh: lh > rh),
+            GtEq: partial(self._comp_expr_matches, lambda lh, rh: lh >= rh),
+        }
+        self._matches = self._expr_matches(expr)
+
+    def _and_expr_matches(self, expr):
+        return (self._expr_matches(expr.lh_expr) and
+                self._expr_matches(expr.rh_expr))
+
+    def _not_expr_matches(self, expr):
+        return not self._expr_matches(expr.expr)
+
+    def _resolve_event_expr(self, event, expr):
+        # event not found
+        if event is None:
+            return
+
+        # event name
+        if type(expr.child) is EventName:
+            return event.name
+
+        # default, automatic dynamic scope
+        dyn_scope = DynScope.AUTO
+
+        if type(expr.child) is DynamicScope:
+            # select specific dynamic scope
+            expr = expr.child
+            dyn_scope = expr.dyn_scope
+
+        if type(expr.child) is EventFieldName:
+            expr = expr.child
+
+            if dyn_scope == DynScope.AUTO:
+                # automatic dynamic scope
+                if expr.name in event:
+                    return event[expr.name]
+
+                # event field not found
+                return
+
+            # specific dynamic scope
+            bt_ctf_scope = _DYN_SCOPE_TO_BT_CTF_SCOPE[dyn_scope]
+
+            return event.field_with_scope(expr.name, bt_ctf_scope)
+
+        assert(False)
+
+    # This exquisite method takes an expression and resolves it to
+    # an actual value (Python's number/string) considering the current
+    # matching context.
+    def _resolve_expr(self, expr):
+        if type(expr) is ParentScope:
+            begin_scope = expr.child
+            event_scope = begin_scope.child
+
+            return self._resolve_event_expr(
+                    self._match_context.parent_begin_evt,
+                    event_scope)
+
+        if type(expr) is BeginScope:
+            # event in the begin context
+            event_scope = expr.child
+
+            return self._resolve_event_expr(self._match_context.begin_evt,
+                                            event_scope)
+
+        if type(expr) is EventScope:
+            # current event
+            return self._resolve_event_expr(self._match_context.evt, expr)
+
+        if type(expr) is Number:
+            return expr.value
+
+        if type(expr) is String:
+            return expr.value
+
+        assert(False)
+
+    def _comp_expr_matches(self, compfn, expr):
+        lh_value = self._resolve_expr(expr.lh_expr)
+        rh_value = self._resolve_expr(expr.rh_expr)
+
+        # make sure both sides are found
+        if lh_value is None or rh_value is None:
+            return False
+
+        # cast RHS to int if LHS is an int
+        if type(lh_value) is int and type(rh_value) is float:
+            rh_value = int(rh_value)
+
+        # compare types first
+        if type(lh_value) is not type(rh_value):
+            return False
+
+        # compare field to a literal value
+        return compfn(lh_value, rh_value)
+
+    def _expr_matches(self, expr):
+        return self._expr_matchers[type(expr)](expr)
+
+    @property
+    def matches(self):
+        return self._matches
+
+
+def _expr_matches(expr, match_context):
+    return _Matcher(expr, match_context).matches
+
+
+def create_conjunction_from_exprs(exprs):
+    if len(exprs) == 0:
+        return
+
+    cur_expr = exprs[0]
+
+    for expr in exprs[1:]:
+        cur_expr = LogicalAnd(cur_expr, expr)
+
+    return cur_expr
+
+
+@enum.unique
+class PeriodEngineCallbackType(enum.Enum):
+    PERIOD_BEGIN = 1
+    PERIOD_END = 2
+
+
+class Period:
+    def __init__(self, definition, parent, begin_evt):
+        begin_evt_copy = core_event.Event(begin_evt)
+        self._begin_evt = begin_evt_copy
+        self._definition = definition
+        self._parent = parent
+        self._children = set()
+
+    @property
+    def begin_evt(self):
+        return self._begin_evt
+
+    @property
+    def definition(self):
+        return self._definition
+
+    @property
+    def parent(self):
+        return self._parent
+
+    @property
+    def children(self):
+        return self._children
+
+
+class PeriodEngine:
+    def __init__(self,  registry, cbs):
+        self._registry = registry
+        self._cbs = cbs
+        self._root_periods = set()
+
+    def _cb_period_end(self, period, completed, evt):
+        self._cbs[PeriodEngineCallbackType.PERIOD_END](period, completed, evt)
+
+    def _cb_period_begin(self, period, evt):
+        self._cbs[PeriodEngineCallbackType.PERIOD_BEGIN](period, evt)
+
+    def _create_period(self, definition, parent, begin_evt):
+        return Period(definition, parent, begin_evt)
+
+    def _process_event_add_periods(self, parent_period,
+                                   child_periods, child_period_defs, evt):
+        periods_to_add = set()
+
+        for child_period_def in child_period_defs:
+            match_context = _MatchContext(evt, evt, None)
+
+            if _expr_matches(child_period_def.begin_expr, match_context):
+                # match! add period
+                period = self._create_period(child_period_def,
+                                             parent_period, evt)
+                periods_to_add.add(period)
+
+        # safe to add child periods now, outside the iteration
+        for period_to_add in periods_to_add:
+            self._cb_period_begin(period_to_add, evt)
+            child_periods.add(period_to_add)
+
+        for child_period in child_periods:
+            self._process_event_add_periods(child_period,
+                                            child_period.children,
+                                            child_period.definition.children,
+                                            evt)
+
+    def _process_event_begin(self, evt):
+        defs = self._registry.root_period_defs
+        self._process_event_add_periods(None, self._root_periods, defs, evt)
+
+    def _create_end_match_context(self, period, evt):
+        parent_begin_evt = None
+
+        if period.parent is not None:
+            parent_begin_evt = period.parent.begin_evt
+
+        return _MatchContext(evt, period.begin_evt, parent_begin_evt)
+
+    def _process_event_remove_period(self, child_periods, evt):
+        for child_period in child_periods:
+            self._process_event_remove_period(child_period.children, evt)
+
+        child_periods_to_remove = set()
+
+        for child_period in child_periods:
+            match_context = self._create_end_match_context(child_period, evt)
+
+            if _expr_matches(child_period.definition.end_expr, match_context):
+                child_periods_to_remove.add(child_period)
+
+        # safe to remove child periods now, outside the iteration
+        for child_period_to_remove in child_periods_to_remove:
+            # also remove its own remaining child periods
+            self._remove_periods(child_period_to_remove.children, evt)
+
+            # call end of period user callback (this period matched)
+            self._cb_period_end(child_period_to_remove, True, evt)
+
+            # remove period from set
+            child_periods.remove(child_period_to_remove)
+
+    def _process_event_end(self, evt):
+        self._process_event_remove_period(self._root_periods, evt)
+
+    def process_event(self, evt):
+        self._process_event_end(evt)
+        self._process_event_begin(evt)
+
+    def _remove_periods(self, child_periods, evt):
+        for child_period in child_periods:
+            self._remove_periods(child_period.children, evt)
+
+        # safe to remove child periods now, outside the iteration
+        for child_period in child_periods:
+            self._cb_period_end(child_period, False, evt)
+
+        child_periods.clear()
+
+    def remove_all_periods(self):
+        self._remove_periods(self._root_periods, None)
+
+    @property
+    def root_periods(self):
+        return self._root_periods

--- a/lttnganalyses/core/period.py
+++ b/lttnganalyses/core/period.py
@@ -527,6 +527,18 @@ def create_conjunction_from_exprs(exprs):
     return cur_expr
 
 
+def create_disjunction_from_exprs(exprs):
+    if len(exprs) == 0:
+        return
+
+    cur_expr = exprs[0]
+
+    for expr in exprs[1:]:
+        cur_expr = LogicalOr(cur_expr, expr)
+
+    return cur_expr
+
+
 @enum.unique
 class PeriodEngineCallbackType(enum.Enum):
     PERIOD_BEGIN = 1

--- a/lttnganalyses/core/periods.py
+++ b/lttnganalyses/core/periods.py
@@ -78,7 +78,7 @@ class PeriodAnalysis(Analysis):
         self._all_period_list.append(period_event)
 
     # beginning of a new period
-    def _begin_period_cb(self, period_data, evt):
+    def _begin_period_cb(self, period_data):
         if period_data.period.definition is None:
             return
 
@@ -88,7 +88,7 @@ class PeriodAnalysis(Analysis):
             self._all_period_stats[definition.name] = \
                 PeriodStats.new_from_period(period_data.period)
 
-    def _end_period_cb(self, period_data, evt):
+    def _end_period_cb(self, period_data):
         period = period_data.period
 
         if period.definition is None:

--- a/lttnganalyses/core/periods.py
+++ b/lttnganalyses/core/periods.py
@@ -160,3 +160,11 @@ class PeriodEvent():
     @property
     def duration(self):
         return self._end_ts - self._start_ts
+
+    @property
+    def begin_captures(self):
+        return str(self._begin_captures)
+
+    @property
+    def end_captures(self):
+        return str(self._end_captures)

--- a/lttnganalyses/core/periods.py
+++ b/lttnganalyses/core/periods.py
@@ -1,0 +1,153 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2016 - Julien Desfossez <jdesfossez@efficios.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from .analysis import Analysis, PeriodData
+
+
+class _PeriodData(PeriodData):
+    pass
+
+
+class PeriodAnalysis(Analysis):
+    def __init__(self, state, conf):
+        super().__init__(state, conf, {})
+        # This is a special case where we keep a global state instead of a
+        # per-period state, since we are accumulating statistics about
+        # all the periods.
+        self._all_period_stats = {}
+        self._all_period_list = []
+        self._all_total_duration = 0
+        self._all_min_duration = None
+        self._all_max_duration = None
+
+    def _create_period_data(self):
+        return _PeriodData()
+
+    @property
+    def all_count(self):
+        return len(self._all_period_list)
+
+    @property
+    def all_period_stats(self):
+        return self._all_period_stats
+
+    @property
+    def all_period_list(self):
+        return self._all_period_list
+
+    @property
+    def all_min_duration(self):
+        return self._all_min_duration
+
+    @property
+    def all_max_duration(self):
+        return self._all_max_duration
+
+    @property
+    def all_total_duration(self):
+        return self._all_total_duration
+
+    def update_global_stats(self, period_event):
+        if self._all_min_duration is None or period_event.duration < \
+                self._all_min_duration:
+            self._all_min_duration = period_event.duration
+
+        if self._all_max_duration is None or period_event.duration > \
+                self._all_max_duration:
+            self._all_max_duration = period_event.duration
+        self._all_total_duration += period_event.duration
+        self._all_period_list.append(period_event)
+
+    # beginning of a new period
+    def _begin_period_cb(self, period_data, evt):
+        if period_data.period.definition is None:
+            return
+
+        definition = period_data.period.definition
+
+        if definition.name not in self._all_period_stats:
+            self._all_period_stats[definition.name] = \
+                PeriodStats.new_from_period(period_data.period)
+
+    def _end_period_cb(self, period_data, evt):
+        period = period_data.period
+
+        if period.definition is None:
+            return
+
+        new_period_evt = PeriodEvent(period.begin_evt.timestamp,
+                                     self.last_event_ts,
+                                     period.definition.name)
+        self._all_period_stats[period.definition.name].update_stats(
+            new_period_evt)
+        self.update_global_stats(new_period_evt)
+
+
+class PeriodStats():
+    def __init__(self, name):
+        self.name = name
+        self.period_list = []
+        self.min_duration = None
+        self.max_duration = None
+        self.total_duration = 0
+
+    @classmethod
+    def new_from_period(cls, period):
+        return cls(period.definition.name)
+
+    @property
+    def count(self):
+        return len(self.period_list)
+
+    def update_stats(self, period_event):
+        if self.min_duration is None or period_event.duration < \
+                self.min_duration:
+            self.min_duration = period_event.duration
+
+        if self.max_duration is None or period_event.duration > \
+                self.max_duration:
+            self.max_duration = period_event.duration
+        self.total_duration += period_event.duration
+        self.period_list.append(period_event)
+
+
+class PeriodEvent():
+    def __init__(self, start_ts, end_ts, name):
+        self._start_ts = start_ts
+        self._end_ts = end_ts
+        self._name = name
+
+    @property
+    def start_ts(self):
+        return self._start_ts
+
+    @property
+    def end_ts(self):
+        return self._end_ts
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def duration(self):
+        return self._end_ts - self._start_ts

--- a/lttnganalyses/core/periods.py
+++ b/lttnganalyses/core/periods.py
@@ -88,15 +88,21 @@ class PeriodAnalysis(Analysis):
             self._all_period_stats[definition.name] = \
                 PeriodStats.new_from_period(period_data.period)
 
-    def _end_period_cb(self, period_data):
+    def _end_period_cb(self, period_data, completed,
+                       begin_captures, end_captures):
         period = period_data.period
 
         if period.definition is None:
             return
 
+        if completed is False:
+            return
+
         new_period_evt = PeriodEvent(period.begin_evt.timestamp,
                                      self.last_event_ts,
-                                     period.definition.name)
+                                     period.definition.name,
+                                     begin_captures,
+                                     end_captures)
         self._all_period_stats[period.definition.name].update_stats(
             new_period_evt)
         self.update_global_stats(new_period_evt)
@@ -131,10 +137,13 @@ class PeriodStats():
 
 
 class PeriodEvent():
-    def __init__(self, start_ts, end_ts, name):
+    def __init__(self, start_ts, end_ts, name, begin_captures,
+                 end_captures):
         self._start_ts = start_ts
         self._end_ts = end_ts
         self._name = name
+        self._begin_captures = begin_captures
+        self._end_captures = end_captures
 
     @property
     def start_ts(self):

--- a/lttnganalyses/core/syscalls.py
+++ b/lttnganalyses/core/syscalls.py
@@ -40,7 +40,7 @@ class SyscallsAnalysis(Analysis):
     def _create_period_data(self):
         return _PeriodData()
 
-    def _process_syscall_exit(self, period, **kwargs):
+    def _process_syscall_exit(self, period_data, **kwargs):
         cpu_id = kwargs['cpu_id']
         proc = kwargs['proc']
         tid = proc.tid
@@ -52,16 +52,16 @@ class SyscallsAnalysis(Analysis):
         if not self._filter_cpu(cpu_id):
             return
 
-        if tid not in period.tids:
-            period.tids[tid] = ProcessSyscallStats.new_from_process(proc)
+        if tid not in period_data.tids:
+            period_data.tids[tid] = ProcessSyscallStats.new_from_process(proc)
 
-        proc_stats = period.tids[tid]
+        proc_stats = period_data.tids[tid]
         if name not in proc_stats.syscalls:
             proc_stats.syscalls[name] = SyscallStats(name)
 
         proc_stats.syscalls[name].update_stats(current_syscall)
         proc_stats.total_syscalls += 1
-        period.total_syscalls += 1
+        period_data.total_syscalls += 1
 
 
 class ProcessSyscallStats(stats.Process):

--- a/lttnganalyses/linuxautomaton/automaton.py
+++ b/lttnganalyses/linuxautomaton/automaton.py
@@ -43,22 +43,22 @@ class State:
         # version of tracer used, so keep track of it.
         self._tracer_version = None
 
-    def register_notification_cbs(self, period, cbs):
+    def register_notification_cbs(self, period_data, cbs):
         for name in cbs:
             if name not in self._notification_cbs:
                 self._notification_cbs[name] = []
-            # Store the callback in the form of (period, function)
-            self._notification_cbs[name].append((period, cbs[name]))
+            # Store the callback in the form of (period_data, function)
+            self._notification_cbs[name].append((period_data, cbs[name]))
 
     def send_notification_cb(self, name, **kwargs):
         if name in self._notification_cbs:
             for cb_tuple in self._notification_cbs[name]:
                 cb_tuple[1](cb_tuple[0], **kwargs)
 
-    def clear_period_notification_cbs(self, period):
+    def clear_period_notification_cbs(self, period_data):
         for name in self._notification_cbs:
             for cb in self._notification_cbs[name]:
-                if cb[0] == period:
+                if cb[0] == period_data:
                     self._notification_cbs[name].remove(cb)
 
 

--- a/lttnganalyses/linuxautomaton/automaton.py
+++ b/lttnganalyses/linuxautomaton/automaton.py
@@ -43,17 +43,23 @@ class State:
         # version of tracer used, so keep track of it.
         self._tracer_version = None
 
-    def register_notification_cbs(self, cbs):
+    def register_notification_cbs(self, period, cbs):
         for name in cbs:
             if name not in self._notification_cbs:
                 self._notification_cbs[name] = []
-
-            self._notification_cbs[name].append(cbs[name])
+            # Store the callback in the form of (period, function)
+            self._notification_cbs[name].append((period, cbs[name]))
 
     def send_notification_cb(self, name, **kwargs):
         if name in self._notification_cbs:
+            for cb_tuple in self._notification_cbs[name]:
+                cb_tuple[1](cb_tuple[0], **kwargs)
+
+    def clear_period_notification_cbs(self, period):
+        for name in self._notification_cbs:
             for cb in self._notification_cbs[name]:
-                cb(**kwargs)
+                if cb[0] == period:
+                    self._notification_cbs[name].remove(cb)
 
 
 class Automaton:

--- a/lttnganalyses/linuxautomaton/block.py
+++ b/lttnganalyses/linuxautomaton/block.py
@@ -77,7 +77,7 @@ class BlockStateProvider(sp.StateProvider):
                 break
 
         if dev not in self._state.disks:
-            self._state.disks[dev] = sv.Disk()
+            self._state.disks[dev] = sv.Disk(dev)
 
         self._state.disks[dev].pending_requests[sector] = req
 
@@ -96,7 +96,7 @@ class BlockStateProvider(sp.StateProvider):
                 break
 
         if dev not in self._state.disks:
-            self._state.disks[dev] = sv.Disk()
+            self._state.disks[dev] = sv.Disk(dev)
 
         disk = self._state.disks[dev]
 
@@ -115,5 +115,6 @@ class BlockStateProvider(sp.StateProvider):
         else:
             proc = None
         self._state.send_notification_cb('block_rq_complete', req=req,
-                                         proc=proc, cpu_id=event['cpu_id'])
+                                         proc=proc, cpu_id=event['cpu_id'],
+                                         disk=disk)
         del disk.pending_requests[sector]

--- a/lttnganalyses/linuxautomaton/statedump.py
+++ b/lttnganalyses/linuxautomaton/statedump.py
@@ -31,10 +31,23 @@ class StatedumpStateProvider(sp.StateProvider):
             'lttng_statedump_process_state':
             self._process_lttng_statedump_process_state,
             'lttng_statedump_file_descriptor':
-            self._process_lttng_statedump_file_descriptor
+            self._process_lttng_statedump_file_descriptor,
+            'lttng_statedump_block_device':
+            self._process_lttng_statedump_block_device
         }
 
         super().__init__(state, cbs)
+
+    def _process_lttng_statedump_block_device(self, event):
+        dev = event['dev']
+        diskname = event['diskname']
+
+        if dev not in self._state.disks:
+            self._state.disks[dev] = sv.Disk(dev, diskname=diskname)
+        elif self._state.disks[dev] is None:
+            self._state.disks[dev].diskname = diskname
+        self._state.send_notification_cb('lttng_statedump_block_device',
+                                         dev=dev, diskname=diskname)
 
     def _process_lttng_statedump_process_state(self, event):
         tid = event['tid']

--- a/lttnganalyses/linuxautomaton/statedump.py
+++ b/lttnganalyses/linuxautomaton/statedump.py
@@ -44,7 +44,7 @@ class StatedumpStateProvider(sp.StateProvider):
 
         if dev not in self._state.disks:
             self._state.disks[dev] = sv.Disk(dev, diskname=diskname)
-        elif self._state.disks[dev] is None:
+        elif self._state.disks[dev].diskname is None:
             self._state.disks[dev].diskname = diskname
         self._state.send_notification_cb('lttng_statedump_block_device',
                                          dev=dev, diskname=diskname)

--- a/lttnganalyses/linuxautomaton/sv.py
+++ b/lttnganalyses/linuxautomaton/sv.py
@@ -85,7 +85,9 @@ class SyscallEvent():
 
 
 class Disk():
-    def __init__(self):
+    def __init__(self, dev, diskname=None):
+        self.dev = dev
+        self.diskname = diskname
         # pending block IO Requests, indexed by sector
         self.pending_requests = {}
 

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,10 @@ setup(
             'lttng-schedtop = lttnganalyses.cli.sched:runtop',
             'lttng-schedstats = lttnganalyses.cli.sched:runstats',
             'lttng-schedfreq = lttnganalyses.cli.sched:runfreq',
+            'lttng-periodlog = lttnganalyses.cli.periods:runlog',
+            'lttng-periodtop = lttnganalyses.cli.periods:runtop',
+            'lttng-periodstats = lttnganalyses.cli.periods:runstats',
+            'lttng-periodfreq = lttnganalyses.cli.periods:runfreq',
 
             # MI mode
             'lttng-cputop-mi = lttnganalyses.cli.cputop:run_mi',
@@ -124,12 +128,20 @@ setup(
             'lttng-schedtop-mi = lttnganalyses.cli.sched:runtop_mi',
             'lttng-schedstats-mi = lttnganalyses.cli.sched:runstats_mi',
             'lttng-schedfreq-mi = lttnganalyses.cli.sched:runfreq_mi',
+            'lttng-periodlog-mi = lttnganalyses.cli.periods:runlog_mi',
+            'lttng-periodtop-mi = lttnganalyses.cli.periods:runtop_mi',
+            'lttng-periodstats-mi = lttnganalyses.cli.periods:runstats_mi',
+            'lttng-periodfreq-mi = lttnganalyses.cli.periods:runfreq_mi',
         ],
     },
 
     scripts=[
         'lttng-analyses-record',
         'lttng-track-process'
+    ],
+
+    install_requires=[
+        'pyparsing',
     ],
 
     extras_require={

--- a/tests_long_regression/test_all_options.py
+++ b/tests_long_regression/test_all_options.py
@@ -1,0 +1,316 @@
+# The MIT License (MIT)
+#
+# Copyright (C) 2016 - Julien Desfossez <jdesfossez@efficios.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the 'Software'), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import shutil
+import subprocess
+import unittest
+import tempfile
+
+
+class _RefTrace():
+    def __init__(self, repo_path, name, begin_ts, end_ts, period1=None,
+                 period2=None):
+        # Directory containing all the trace archives
+        repo_path = os.path.join(repo_path, "traces")
+        # Path of the extracted trace
+        self._path = os.path.join(repo_path, name)
+        # Name of the trace without the tar.xz suffix
+        self._name = name
+        # begin_ts is a valid timestamp inside the trace but not the first
+        # event.
+        # end_ts is a valid timestamp inside the trace but not the last event.
+        # Timestamps are in the GMT timezone
+        self._begin_ts = begin_ts
+        self._end_ts = end_ts
+        # Optional period definitions
+        self._period1 = period1
+        self._period2 = period2
+
+        self._extract_trace(repo_path, self._path)
+
+    @property
+    def path(self):
+        return self._path
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def begin_ts(self):
+        return self._begin_ts
+
+    @property
+    def end_ts(self):
+        return self._end_ts
+
+    @property
+    def period1(self):
+        return self._period1
+
+    @property
+    def period2(self):
+        return self._period2
+
+    def _extract_trace(self, repo_path, path):
+        subprocess.check_output("tar -C %s -xJf %s.tar.xz" % (
+            repo_path, path), shell=True)
+
+
+class TestAllOptions(unittest.TestCase):
+    COMMON_OPTIONS = '--no-color --no-progress --skip-validation --gmt'
+
+    # Get the traces only once for all the tests
+    @classmethod
+    def setUpClass(cls):
+        super(TestAllOptions, cls).setUpClass()
+        cls._traces_repo = "https://github.com/lttng/lttng-ref-traces"
+        cls._traces_repo_path = tempfile.mkdtemp()
+        cls._traces = {}
+        cls.get_traces(cls)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls._traces_repo_path)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._out_of_scope_ts_begin = '2032-01-01 15:58:26'
+        self._out_of_scope_ts_end = '2032-01-10 15:58:27'
+
+    def get_traces(self):
+        # This asserts on error, so the test fails
+        subprocess.check_output("git clone %s %s" % (
+            self._traces_repo, self._traces_repo_path), shell=True)
+        self._traces["picotrace"] = _RefTrace(
+                self._traces_repo_path, "picotrace",
+                "1970-01-01 00:00:01.004000000",
+                "1970-01-01 i00:00:01.022000000")
+        self._traces["16-cores-rt"] = _RefTrace(
+                self._traces_repo_path, "16-cores-rt",
+                "2016-07-20 18:02:05.196332110",
+                "2016-07-20 18:02:07.282598088")
+
+    def get_cmd_return(self, test_name, exec_name, options):
+        cmd_fmt = './{} {} {} {}'
+
+        # Create an utf-8 test env
+        test_env = os.environ.copy()
+        test_env['LC_ALL'] = 'C.UTF-8'
+
+        for t in self._traces.keys():
+            trace = self._traces[t]
+            options = options.replace('$BEGIN_TS$', trace.begin_ts)
+            options = options.replace('$END_TS$', trace.end_ts)
+            cmd = cmd_fmt.format(exec_name, self.COMMON_OPTIONS, options,
+                                 trace.path)
+            print(cmd)
+            process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+                                       stderr=subprocess.STDOUT, env=test_env)
+            output, unused_err = process.communicate()
+            self.assertEqual(process.returncode, 0, msg=test_name)
+
+        return output
+
+    def run_with_common_options(self, exec_name):
+        self.get_cmd_return('default', exec_name, '')
+        self.get_cmd_return('refresh 1 sec', exec_name, '-r 1')
+        self.get_cmd_return('--cpu', exec_name, '--cpu 0')
+
+        # Timestamp handling
+        self.get_cmd_return('--begin', exec_name, '--begin "$BEGIN_TS$"')
+        self.get_cmd_return('--end', exec_name, '--end "$END_TS$"')
+        self.get_cmd_return('--begin --end', exec_name,
+                            '--begin "$BEGIN_TS$" --end "$END_TS$"')
+        self.get_cmd_return('--timerange', exec_name,
+                            '--timerange "[$BEGIN_TS$, $END_TS$]"')
+        # Out-of-scope timestamps (empty dataset)
+        self.get_cmd_return('--begin', exec_name, '--begin "%s"' % (
+            self._out_of_scope_ts_begin))
+        self.get_cmd_return('--end', exec_name, '--end "%s"' % (
+            self._out_of_scope_ts_end))
+        self.get_cmd_return('--begin --end', exec_name,
+                            '--begin "%s" --end "%s"' % (
+                                self._out_of_scope_ts_begin,
+                                self._out_of_scope_ts_end))
+        self.get_cmd_return('--timerange', exec_name,
+                            '--timerange "[%s,%s]"' % (
+                                self._out_of_scope_ts_begin,
+                                self._out_of_scope_ts_end))
+
+    def run_with_proc_filter_args(self, exec_name):
+        self.get_cmd_return('--tid', exec_name, '--tid 0')
+        self.get_cmd_return('--procname', exec_name, '--procname test')
+
+    def run_with_min_max_args(self, exec_name):
+        self.get_cmd_return('--min', exec_name, '--min 0')
+        self.get_cmd_return('--max', exec_name, '--max 0')
+
+    def run_with_freq_args(self, exec_name):
+        self.get_cmd_return('--freq', exec_name, '--freq')
+        self.get_cmd_return('--freq-resolution', exec_name,
+                            '--freq-resolution 10')
+        self.get_cmd_return('--freq-uniform', exec_name, '--freq-uniform')
+        self.get_cmd_return('--freq-series', exec_name, '--freq-series')
+
+    def run_with_log_args(self, exec_name):
+        self.get_cmd_return('--log', exec_name, '--log')
+
+    def run_with_top_args(self, exec_name):
+        self.get_cmd_return('--top', exec_name, '--top')
+        self.get_cmd_return('--limit', exec_name, '--limit 0')
+
+    def run_with_stats_args(self, exec_name):
+        self.get_cmd_return('--stats', exec_name, '--stats')
+
+    # lttng-cputop
+    def test_all_options_cputop(self):
+        exec_name = 'lttng-cputop'
+        self.run_with_common_options(exec_name)
+        self.run_with_proc_filter_args(exec_name)
+        self.run_with_top_args(exec_name)
+
+    # lttng-io*
+    def run_all_options_io(self, exec_name):
+        self.run_with_common_options(exec_name)
+        self.run_with_min_max_args(exec_name)
+        self.run_with_freq_args(exec_name)
+        self.run_with_log_args(exec_name)
+        self.run_with_top_args(exec_name)
+        self.run_with_stats_args(exec_name)
+        self.get_cmd_return('--minsize', exec_name, '--minsize 0')
+        self.get_cmd_return('--maxsize', exec_name, '--maxsize 0')
+
+    def test_all_options_iolatencyfreq(self):
+        exec_name = 'lttng-iolatencyfreq'
+        self.run_all_options_io(exec_name)
+
+    def test_all_options_iolatencystats(self):
+        exec_name = 'lttng-iolatencystats'
+        self.run_all_options_io(exec_name)
+
+    def test_all_options_iolatencytop(self):
+        exec_name = 'lttng-iolatencytop'
+        self.run_all_options_io(exec_name)
+
+    # lttng-irq*
+    def run_all_options_irq(self, exec_name):
+        self.run_with_common_options(exec_name)
+        self.run_with_min_max_args(exec_name)
+        self.run_with_freq_args(exec_name)
+        self.run_with_log_args(exec_name)
+        self.run_with_stats_args(exec_name)
+        self.get_cmd_return('--irq', exec_name, '--irq 0')
+        self.get_cmd_return('--softirq', exec_name, '--softirq 0')
+
+    def test_all_options_irqfreq(self):
+        exec_name = 'lttng-irqfreq'
+        self.run_all_options_irq(exec_name)
+
+    def test_all_options_irqlog(self):
+        exec_name = 'lttng-irqlog'
+        self.run_all_options_irq(exec_name)
+
+    def test_all_options_irqstats(self):
+        exec_name = 'lttng-irqstats'
+        self.run_all_options_irq(exec_name)
+
+    # lttng-memtop
+    def test_all_options_memtop(self):
+        exec_name = 'lttng-memtop'
+        self.run_with_common_options(exec_name)
+        self.run_with_proc_filter_args(exec_name)
+        self.run_with_top_args(exec_name)
+
+    # lttng-period*
+    def run_all_options_period(self, exec_name):
+        self.run_with_common_options(exec_name)
+        self.run_with_min_max_args(exec_name)
+        self.run_with_freq_args(exec_name)
+        self.run_with_log_args(exec_name)
+        self.run_with_stats_args(exec_name)
+        self.run_with_top_args(exec_name)
+        self.get_cmd_return('--total', exec_name, '--total')
+        self.get_cmd_return('--per-period', exec_name, '--per-period')
+
+    def test_all_options_periodfreq(self):
+        exec_name = 'lttng-periodfreq'
+        self.get_cmd_return('--per-period --freq-uniform', exec_name,
+                            '--per-period --freq-uniform')
+        self.get_cmd_return('--total --freq-uniform', exec_name,
+                            '--total --freq-uniform')
+        self.run_all_options_period(exec_name)
+
+    def test_all_options_periodlog(self):
+        exec_name = 'lttng-periodlog'
+        self.run_all_options_period(exec_name)
+
+    def test_all_options_periodstats(self):
+        exec_name = 'lttng-periodstats'
+        self.run_all_options_period(exec_name)
+
+    def test_all_options_periodtop(self):
+        exec_name = 'lttng-periodtop'
+        self.run_all_options_period(exec_name)
+
+    # lttng-sched*
+    def run_all_options_sched(self, exec_name):
+        self.run_with_common_options(exec_name)
+        self.run_with_proc_filter_args(exec_name)
+        self.run_with_min_max_args(exec_name)
+        self.run_with_freq_args(exec_name)
+        self.run_with_log_args(exec_name)
+        self.run_with_top_args(exec_name)
+        self.run_with_stats_args(exec_name)
+        self.get_cmd_return('--total', exec_name, '--total')
+        self.get_cmd_return('--per-tid', exec_name, '--per-tid')
+        self.get_cmd_return('--per-prio', exec_name, '--per-prio')
+
+    def test_all_options_schedtop(self):
+        exec_name = 'lttng-schedtop'
+        self.run_all_options_sched(exec_name)
+
+    def test_all_options_schedfreq(self):
+        exec_name = 'lttng-schedfreq'
+        self.run_all_options_sched(exec_name)
+        self.get_cmd_return('--per-prio --freq-uniform', exec_name,
+                            '--per-prio --freq-uniform')
+        self.get_cmd_return('--per-tid --freq-uniform', exec_name,
+                            '--per-tid --freq-uniform')
+        self.get_cmd_return('--total --freq-uniform', exec_name,
+                            '--total --freq-uniform')
+
+    def test_all_options_schedlog(self):
+        exec_name = 'lttng-schedlog'
+        self.run_all_options_sched(exec_name)
+
+    def test_all_options_schedstats(self):
+        exec_name = 'lttng-schedstats'
+        self.run_all_options_sched(exec_name)
+
+    # lttng-syscallstats
+    def test_all_options_syscallstats(self):
+        exec_name = 'lttng-syscallstats'
+        self.run_with_common_options(exec_name)
+        self.run_with_proc_filter_args(exec_name)


### PR DESCRIPTION
The main changes in this PR for the core of the project is the handling of the analyses data. Instead of storing the data in the analyses modules (core/*.py), we store it in period objects that belong to the analyses. For each active period, a different set of callbacks is registered to the automaton with the period data object as parameter, so they all exist in parallel with no shared data. This allows us to have multiple analyses running in parallel.

Now, when a period starts, an empty period data object is created, when the period ends, the data of that period is sent to the cli module for eventual printing (or storage in MI), then the period data object is destroyed.

A period starts at the beginning of the trace if no --period argument is passed. If the --refresh argument is passed, everytime we output the data, we destroy the previous period and start a new one (instead of the old "reset" mechanism we had). If the --period argument is passed, then everytime a period begin condition matches, a new period is created.

The new --period allows the user to specifiy conditions for beginning and ending a period, this argument can be specified multiple times and period can depend on each other (with access to the parent arguments). The full usage documentation is in the commit message introducing this feature.

The old --period-* arguments are kept for this release but are now deprecated (a warning is output), and they have been reworked to use the new backend.

A couple of unrelated bugfixes and test updates are also part of this PR.