### PR TITLE
Remove mention of Trace Compass 2.0 compatibility issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,20 +48,6 @@ to "dig" until the root cause is found.
 Install LTTng analyses
 ======================
 
-.. NOTE::
-
-   The version 2.0 of `Trace Compass <http://tracecompass.org/>`_
-   requires LTTng analyses 0.4: Trace Compass 2.0 is not compatible
-   with LTTng analyses 0.5 and after.
-
-   In this case, we suggest that you install LTTng analyses from the
-   ``stable-0.4`` branch of the project's Git repository (see
-   `Install from the Git repository`_). You can also
-   `download <https://github.com/lttng/lttng-analyses/releases>`_ the
-   latest 0.4 release tarball and follow the
-   `Install from a release tarball`_ procedure.
-
-
 Required dependencies
 ---------------------
 


### PR DESCRIPTION
Trace Compass 2.1 and 2.2 were released since this note was added. Those versions no longer require lttng-analyses 0.4.

We may still want to mention this problem (although it seems to belong in Trace Compass' documentation, not lttng-analyses').