### PR TITLE
Remove README note about Trace Compass 2.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,19 +48,6 @@ to "dig" until the root cause is found.
 Install LTTng analyses
 ======================
 
-.. NOTE::
-
-   The version 2.0 of `Trace Compass <http://tracecompass.org/>`_
-   requires LTTng analyses 0.4: Trace Compass 2.0 is not compatible
-   with LTTng analyses 0.5 and after.
-
-   In this case, we suggest that you install LTTng analyses from the
-   ``stable-0.4`` branch of the project's Git repository (see
-   `Install from the Git repository`_). You can also
-   `download <https://github.com/lttng/lttng-analyses/releases>`_ the
-   latest 0.4 release tarball and follow the
-   `Install from a release tarball`_ procedure.
-
 
 Required dependencies
 ---------------------


### PR DESCRIPTION
It mislead some users into thinking Trace Compass was a dependency of
LTTng-Analyses, while it's the other way around!

Latest stable versions of Trace Compass support the 1.0 LAMI
specification, so it should not be required anymore.

Signed-off-by: Alexandre Montplaisir <alexmonthy@efficios.com>