### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: generic
 sudo: required
-dist: trusty
+dist: bionic
 os: linux
 
 arch:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: generic
 sudo: required
 dist: trusty
+os: linux
+
+arch:
+ - amd64
+ - ppc64le
+ 
 env:
   matrix:
     - TOXENV=py3


### PR DESCRIPTION
Add support for architecture ppc64le.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. 
For more info tag @gerrith3
Change the distro to Xenial because the package requires python >= 3.5.